### PR TITLE
correct forward symbol typo

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -125,7 +125,7 @@ module Kitchen
 
       def build_run_command(image_id)
         cmd = 'docker run -d'
-        Array(config[:foward]).each {|port| cmd << " -p #{port}"}
+        Array(config[:forward]).each {|port| cmd << " -p #{port}"}
         Array(config[:dns]).each {|dns| cmd << " -dns #{dns}"}
         Array(config[:volume]).each {|volume| cmd << " -v #{volume}"}
         cmd << " -m #{config[:memory]}" if config[:memory]


### PR DESCRIPTION
Looks like a typo for the forward symbol in the config hash
