### PR TITLE
Add a set of computed defaults for a couple of known platform names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,33 @@ platforms:
   - recipe[yum]
 ```
 
+## Default Configuration
+
+This driver can determine an image and platform type for a select number of
+platforms. Currently, the following platform names are supported:
+
+```
+---
+platforms:
+- name: ubuntu-12.04
+- name: centos-6.4
+```
+
+This will effectively generate a configuration similar to:
+
+```
+---
+platforms:
+- name: ubuntu-12.04
+  driver_config:
+    image: ubuntu:12.04
+    platform: ubuntu
+- name: centos-6.4
+  driver_config:
+    image: centos:6.4
+    platform: centos
+```
+
 ## Configuration
 
 ### image
@@ -39,7 +66,10 @@ platforms:
 The Docker image to use as the base for the suite containers. You can find
 images using the [Docker Index][docker_index].
 
-The default value is `base`, an official Ubuntu [image][docker_default_image].
+The default will be determined by the Platform name, if a default exists
+(see the Default Configuration section for more details). If a default
+cannot be computed, then the default value is `base`, an official Ubuntu
+[image][docker_default_image].
 
 ### platform
 
@@ -49,7 +79,9 @@ suite container for Test Kitchen. Kitchen Docker currently supports:
 * `debian` or `ubuntu`
 * `rhel` or `centos`
 
-The default value is `ubuntu`.
+The default will be determined by the Platform name, if a default exists
+(see the Default Configuration section for more details). If a default
+cannot be computed, then the default value is `ubuntu`.
 
 ### require\_chef\_omnibus
 

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -29,14 +29,18 @@ module Kitchen
     # @author Sean Porter <portertech@gmail.com>
     class Docker < Kitchen::Driver::SSHBase
 
-      default_config :image,                'base'
-      default_config :platform,             'ubuntu'
       default_config :port,                 '22'
       default_config :username,             'kitchen'
       default_config :password,             'kitchen'
       default_config :require_chef_omnibus, true
       default_config :remove_images,        false
       default_config :use_sudo,             true
+      default_config :image do |driver|
+        driver.default_image
+      end
+      default_config :platform do |driver|
+        driver.default_platform
+      end
 
       def verify_dependencies
         run_command('docker > /dev/null', :quiet => true)
@@ -57,6 +61,21 @@ module Kitchen
         if config[:remove_images] && state[:image_id]
           rm_image(state)
         end
+      end
+
+      def default_image
+        case instance.platform.name
+        when 'ubuntu-12.04'
+          'ubuntu:12.04'
+        when 'centos-6.4'
+          'centos:6.4'
+        else
+          'base'
+        end
+      end
+
+      def default_platform
+        instance.platform.name.split('-').first || 'ubuntu'
       end
 
       protected


### PR DESCRIPTION
Currently given these platform names, the image and platform values can
be auto-generated:
- ubuntu-12.04
- centos-6.4
