### PR TITLE
Added option privileged which defaults to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Examples:
   hostname: mah-host.wicked-domain.com
 ```
 
-## privileged_mode
+## privileged
 
 By default docker containers run as unprivileged. This option sets the
 `-privileged=true` option for docker when the container is started. This

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -31,7 +31,7 @@ module Kitchen
       default_config :require_chef_omnibus, true
       default_config :remove_images,        false
       default_config :use_sudo,             true
-      default_config :privileged_mode,      false
+      default_config :privileged,           false
 
       default_config :image do |driver|
         driver.default_image
@@ -151,7 +151,7 @@ module Kitchen
 
       def build_run_command(image_id)
         cmd = "run -d -p 22"
-        cmd << " -privileged=true" if config[:privileged_mode]
+        cmd << " -privileged=true" if config[:privileged]
         Array(config[:forward]).each {|port| cmd << " -p #{port}"}
         Array(config[:dns]).each {|dns| cmd << " -dns #{dns}"}
         Array(config[:volume]).each {|volume| cmd << " -v #{volume}"}


### PR DESCRIPTION
This PR adds the option :privileged to allow running docker containers with -privileged=true. This was necessary in our case to permit mounting volumes inside the container, something we are doing in some cookbooks. 

Example .kitchen.yml with this option:

driver_plugin: docker
provisioner: chef_zero
platforms:
- name: centos-6.4
  driver_config:
    require_chef_omnibus: 11.6.0
    privileged: true
  suites:
- name: default
  run_list:
  - recipe[selenium]

README was updated with some info about this option. 
