### PR TITLE
Added support for docker-api gem as client

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,25 +117,6 @@ installed. There are several different behaviors available:
 
 The default value is `true`.
 
-### ruby\_client
-
-Determines whether to use the [Docker-api][docker_api_url] gem as your
-docker client. This allows test-kitchen to be run on a host which does
-not natively support Docker (eg. OSX, Windows?) to run tests on a remote
-docker node. Version compatibility with your version of Docker is tested
-at startup and will notify of incompatibilities. 
-
-Note that this option generally is not useful without also setting
-`socket: tcp://some-host:some-port`. 
-
-Examples:
-
-```
-  ruby_client: true
-```
-
-The default value is `false`
-
 ### provision\_command
 
 Custom command(s) to be run when provisioning the base for the suite containers.


### PR DESCRIPTION
Removes requirement that cli tools be installed on host running test-kitchen. This also added a few additional options:

:ruby_client -- (true/false) select whether to use the docker-api as
  your docker client (default false)

:read_timeout -- (int) Choose read timeout used by docker-api during
API operations. This originally defaulted to 60 seconds which was too low
for some Docker::Image.build() operations such as large RPM installs on the first
(uncached) run, bumped to a workable default and made configurable
through kitchen.yml should someone need it to be higher/lower

The port forwarding config code seems unnecessarily complex but the use of the API required substantially more logic around how ports are handled. Would love feedback on ways to improve it. 

All options were compared against the CLI client to make sure things provided equivalent functionality. 

Used the following basic .kitchen.local.yml to test & added options as necessary to test each:

```

---
driver_plugin: docker
driver_config:
  ruby_client: true
  privileged: false
  socket: tcp://192.168.1.3:4242

platforms:
- name: centos-6.4
  run_list:
    - recipe[test-gem]
```

I tested ubuntu-12.04 as well but received the following error using both the docker-api gem and cli client:

```
-----> Converging <default-centos-64>...
D      Creating local sandbox in /var/folders/jt/2g9h3ddn00s6sf3rfbyxwv9rlr07l0/T/default-centos-64-sandbox-20131129-88876-khjd4c
       Resolving cookbook dependencies with Berkshelf...
D      Using Berksfile from /Users/anichols/projects/test-gem/Berksfile
[1]    88876 trace trap  bundle exec kitchen converge --parallel --log-level=debug
```

I didn't dig into this further as behavior was consistent - assuming it's related to test-kitchen or docker themselves. 
