### PR TITLE
run init so container remains accessible after sshd restart

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -29,9 +29,9 @@ module Kitchen
       default_config :socket,        nil
       default_config :privileged,    false
       default_config :remove_images, false
+      default_config :run_command,   '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no'
       default_config :username,      'kitchen'
       default_config :password,      'kitchen'
-      default_config :run_command,   '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no'
 
       default_config :use_sudo do |driver|
         !driver.remote_socket?


### PR DESCRIPTION
currently, running any tests that restart sshd fail when sshd restarts, because the container stops when the run_command exits, and there's no mechanism to restart it.

running the init process will start the ssh daemon at the default runlevel for every system i'm aware of (certainly for the listed platforms), so the end result is the same, but a bit more resilient.
