### PR TITLE
Log output from Docker API gem

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -47,6 +47,8 @@ module Kitchen
         driver.default_platform
       end
 
+      ::Docker.logger = ::Kitchen.logger
+
       def verify_dependencies
         ::Docker.url = config[:socket] if config[:socket]
         ::Docker.options = {


### PR DESCRIPTION
This goes hand-in-hand with docker-api#78

Allows for better debugging of docker API calls through test-kitchen
