### PR TITLE
Use :latest tag instead of base

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -60,7 +60,7 @@ module Kitchen
 
       def default_image
         platform, release = instance.platform.name.split('-')
-        release ? [platform, release].join(':') : 'base'
+        release ? [platform, release].join(':') : "#{platform}:latest"
       end
 
       def default_platform


### PR DESCRIPTION
if platform has no version:

```
platforms:
  - name: centos
```

then base fails if using boot2docker vm, using latest tag instead works.
