### PR TITLE
Look for ENV['DOCKER_HOST'] when setting default socket

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -27,7 +27,7 @@ module Kitchen
     # @author Sean Porter <portertech@gmail.com>
     class Docker < Kitchen::Driver::SSHBase
 
-      default_config :socket,        'unix:///var/run/docker.sock'
+      default_config :socket,        ENV['DOCKER_HOST'] || 'unix:///var/run/docker.sock'
       default_config :privileged,    false
       default_config :remove_images, false
       default_config :run_command,   '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no'


### PR DESCRIPTION
New docker clients will use the `DOCKER_HOST` env variable to determine where to look for the docker daemon.  This change looks for that env before falling back to the hardcoded sock address.  

Support was implemented in docker here: https://github.com/dotcloud/docker/pull/3303
