### PR TITLE
Skip the passphrase prompt on CentOS

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -112,8 +112,8 @@ module Kitchen
           <<-eos
             RUN yum clean all
             RUN yum install -y sudo openssh-server openssh-clients curl
-            RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
-            RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
+            RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
+            RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''
           eos
         else
           raise ActionFailed,


### PR DESCRIPTION
I suddenly began seeing this, and am not sure why, but this fixes it for
me. Otherwise, kitchen runs would hang on generating the key as they
were all stuck at a passphrase prompt.
