### PR TITLE
support alternate system architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,19 @@ Examples:
   privileged: true
 ```
 
+### arch
+
+Change the container's architecture to something other than the same
+as the hosting OS. Note, there's a limitation that this flag is only
+honored at run - with the current docker there's no way to pass in
+arch during 'build'.
+
+Examples:
+
+```
+  arch: i686
+```
+
 ## Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -170,6 +170,7 @@ module Kitchen
         cmd << " -m #{config[:memory]}" if config[:memory]
         cmd << " -c #{config[:cpu]}" if config[:cpu]
         cmd << " -privileged" if config[:privileged]
+        cmd << " --lxc-conf='lxc.arch = #{config[:arch]}'" if config[:arch]
         cmd << " #{image_id} #{config[:run_command]}"
         cmd
       end


### PR DESCRIPTION
This adds support for system architectures other than that of the
hosting system's architecture. This can be used, for example, to test chef
against system i686 system images even though the host is x86_64.

One caveat/drawback I found is that the 'docker build' command does not
allow for changing architecture - only docker run. So if using this the
steps in docker build should make few/no changes to the system - i.e.
make sure the system image already has sudo, openssh, etc installed.
