### PR TITLE
Added necessary requirement to parse socket uri 

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -16,6 +16,7 @@
 
 require 'kitchen'
 require 'json'
+require 'uri'
 require File.join(File.dirname(__FILE__), 'docker', 'erb')
 
 module Kitchen


### PR DESCRIPTION
I noticed that I always got the rescue phrase "You must first install the Docker CLI tool http://www.docker.io/gettingstarted/" because parsing of the socket uri failed with 
`socket_uri': uninitialized constant Kitchen::Driver::Docker::URI (NameError)

Adding `require 'uri'` did the trick for me.
