### PR TITLE
Allow %{instance_name} substitution in bound volumes

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -185,7 +185,10 @@ module Kitchen
         cmd = "run -d -p 22"
         Array(config[:forward]).each {|port| cmd << " -p #{port}"}
         Array(config[:dns]).each {|dns| cmd << " -dns #{dns}"}
-        Array(config[:volume]).each {|volume| cmd << " -v #{volume}"}
+        Array(config[:volume]).each { |volume|
+          formatted = volume % { :instance_name => instance.name }
+          cmd << " -v #{formatted}"
+        }
         cmd << " -h #{config[:hostname]}" if config[:hostname]
         cmd << " -m #{config[:memory]}" if config[:memory]
         cmd << " -c #{config[:cpu]}" if config[:cpu]


### PR DESCRIPTION
This allows you to do clever things, like redirect a directory inside
the container to an outside logs directory named after the instance.