### PR TITLE
Add http proxy and https proxy support to suite containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,24 @@ Examples:
   - 8.8.8.8
   - 8.8.4.4
 ```
+### http\_proxy
 
+Sets an http proxy for the suite container using the `http_proxy` environment variable. 
+
+Examples:
+
+```
+  http_proxy: http://proxy.host.com:8080
+```
+### https\_proxy
+
+Sets an https proxy for the suite container using the `https_proxy` environment variable.
+
+Examples:
+
+```
+  https_proxy: http://proxy.host.com:8080
+```
 ### forward
 
 Set suite container port(s) to forward to the host machine. You may specify

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -117,6 +117,8 @@ module Kitchen
             RUN ln -sf /bin/true /sbin/initctl
           eos
           packages = <<-eos
+            #{"ENV http_proxy " + config[:http_proxy] if config[:http_proxy]}
+            #{"ENV https_proxy " + config[:https_proxy] if config[:https_proxy]}
             ENV DEBIAN_FRONTEND noninteractive
             RUN apt-get update
             RUN apt-get install -y sudo openssh-server curl lsb-release
@@ -124,6 +126,8 @@ module Kitchen
           config[:disable_upstart] ? disable_upstart + packages : packages
         when 'rhel', 'centos'
           <<-eos
+            #{"ENV http_proxy " + config[:http_proxy] if config[:http_proxy]}
+            #{"ENV https_proxy " + config[:https_proxy] if config[:https_proxy]}
             RUN yum clean all
             RUN yum install -y sudo openssh-server openssh-clients which curl
             RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
@@ -131,6 +135,8 @@ module Kitchen
           eos
         when 'arch'
           <<-eos
+            #{"ENV http_proxy " + config[:http_proxy] if config[:http_proxy]}
+            #{"ENV https_proxy " + config[:https_proxy] if config[:https_proxy]}
             RUN pacman -Syu --noconfirm
             RUN pacman -S --noconfirm openssh sudo curl
             RUN ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key


### PR DESCRIPTION
Since I need to use a proxy to get internet access, I needed to have a way to allow the test-kitchen containers to access the internet as well. I have added the ability to configure a proxy for the container through the use of the http_proxy and https_proxy environmental variables.
