### PR TITLE
Official CentOS image changed how it does tagging

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -65,6 +65,9 @@ module Kitchen
 
       def default_image
         platform, release = instance.platform.name.split('-')
+        if platform == "centos" && release
+          release = "centos" + release.split('.').first
+        end
         release ? [platform, release].join(':') : platform
       end
 


### PR DESCRIPTION
Tags: centos6, centos7 (that's it)

eg. centos:centos6
