### PR TITLE
Include proxy in ENV on converge

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -119,8 +119,11 @@ module Kitchen
             RUN dpkg-divert --local --rename --add /sbin/initctl
             RUN ln -sf /bin/true /sbin/initctl
           eos
-          packages = <<-eos
-            ENV DEBIAN_FRONTEND noninteractive
+
+          env = "ENV DEBIAN_FRONTEND noninteractive"
+          env << "\nENV http_proxy #{config[:http_proxy]}" if config[:http_proxy]
+          env << "\nENV https_proxy #{config[:https_proxy]}" if config[:https_proxy]
+          packages = env + <<-eos
             RUN apt-get update
             RUN apt-get install -y sudo openssh-server curl lsb-release
           eos


### PR DESCRIPTION
This patch adds the http_proxy and https_proxy
to the creation of the Dockerfile so that
RUN apt-get update works behind the proxy.

A better approach would probably be to postpone the
RUN commands and execute them interactively after the
inital converge.

*NOTE*: This is not recommended for environments were the proxy settings change. Because this will mess up the container cache. So switching to a non proxy environment uses the cached proxy settings from the layer before/below

Fixes: #72 