### PR TITLE
tell verify_dependencies to be quieter

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -57,7 +57,7 @@ module Kitchen
       default_config :disable_upstart, true
 
       def verify_dependencies
-        run_command("#{config[:binary]} > /dev/null", :quiet => true)
+        run_command("#{config[:binary]} 2> /dev/null", :quiet => true)
         rescue
           raise UserError,
           'You must first install the Docker CLI tool http://www.docker.io/gettingstarted/'


### PR DESCRIPTION
Running anything `kitchen`-related with kitchen-docker now produces lengthy stderr output, which makes it harder to see things.

Add redirection for STDERR when running the docker binary, as now running the `docker` command outputs to STDERR (version 1.2.0).
This is addressed in a [not-yet-released commit](https://github.com/docker/docker/commit/61b129d81802e3c988cc0e67e488b24968dd748a) where the `help` command is redirected.

I tried to find when the stderr was introduced, my go-reading skills aren't there yet.
