### PR TITLE
Add cpuset option to kitchen docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,26 @@ default. You can read more about `memory.limit_in_bytes` [here][memory_limit].
 Sets the CPU shares (relative weight) for the suite container. Otherwise use
 Dockers defaults. You can read more about cpu.shares [here][cpu_shares].
 
+### cpuset
+
+Sets the CPU affinities (i.e. the CPUs on which to allow execution) for the
+suite container. Otherwise use Dockers defaults. You can read more in the
+[docker-run man page][docker_man].
+
+Examples:
+
+```
+  cpuset: 0-3
+```
+
+```
+  cpuset: '0,1'
+```
+Notice that when using commas in the `cpuset` value you **must** quote them as
+a string.
+
+**Note:** This feature is only available in docker versions >= 1.1.0.
+
 ### volume
 
 Adds a data volume(s) to the suite container.
@@ -326,6 +346,7 @@ Apache 2.0 (see [LICENSE][license])
 [docker_upstart_issue]:   https://github.com/dotcloud/docker/issues/223
 [docker_index]:           https://index.docker.io/
 [docker_default_image]:   https://index.docker.io/_/base/
+[docker_man]:             https://github.com/docker/docker/blob/master/docs/man/docker-run.1.md
 [test_kitchen_docs]:      http://kitchen.ci/docs/getting-started/
 [chef_omnibus_dl]:        http://www.opscode.com/chef/install/
 [cpu_shares]:             https://docs.fedoraproject.org/en-US/Fedora/17/html/Resource_Management_Guide/sec-cpu.html

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -57,10 +57,16 @@ module Kitchen
       default_config :disable_upstart, true
 
       def verify_dependencies
-        run_command("#{config[:binary]} > /dev/null", :quiet => true)
+        begin
+          run_command("#{config[:binary]} > /dev/null", :quiet => true)
         rescue
           raise UserError,
           'You must first install the Docker CLI tool http://www.docker.io/gettingstarted/'
+        end
+        if config[:cpuset] && !version_above?('1.1.0')
+          raise UserError, 'The cpuset option is only supported on docker '\
+          'version >= 1.1.0, either remove this option or upgarde docker'
+        end
       end
 
       def default_image
@@ -202,6 +208,7 @@ module Kitchen
         cmd << " -h #{config[:hostname]}" if config[:hostname]
         cmd << " -m #{config[:memory]}" if config[:memory]
         cmd << " -c #{config[:cpu]}" if config[:cpu]
+        cmd << " --cpuset=\"#{config[:cpuset]}\"" if config[:cpuset]
         cmd << " -privileged" if config[:privileged]
         cmd << " -e http_proxy=#{config[:http_proxy]}" if config[:http_proxy]
         cmd << " -e https_proxy=#{config[:https_proxy]}" if config[:https_proxy]
@@ -250,6 +257,12 @@ module Kitchen
       def rm_image(state)
         image_id = state[:image_id]
         docker_command("rmi #{image_id}")
+      end
+
+      def version_above?(version)
+        docker_version = docker_command('--version').split(',').first
+          .scan(/\d+/).join('.')
+        Gem::Version.new(docker_version) >= Gem::Version.new(version)
       end
     end
   end


### PR DESCRIPTION
This adds the cpuset option to allow providing affinities to suite containers.

I also added a mechanism to check the current docker version, as the cpuset feature is only available after 1.1.0. If you specify the option but have an older docker version installed then a UserError is thrown. I felt the best way to deal with this was to fail early and let the user know if they want to use this option then upgrade docker.