### PR TITLE
OSX kitchen commands output failed docker command

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -57,7 +57,7 @@ module Kitchen
       default_config :disable_upstart, true
 
       def verify_dependencies
-        run_command("#{config[:binary]} 2> /dev/null", :quiet => true)
+        run_command("#{config[:binary]} 2> /dev/null")
         rescue
           raise UserError,
           'You must first install the Docker CLI tool http://www.docker.io/gettingstarted/'


### PR DESCRIPTION
With Boot2Docker, kitchen will output docker help from a failed Docker
command.

This happens during the version check of the Docker CLI utility, which
runs on every kitchen command.

This doesn't prevent any kitchen commands from running, but it outputs
the help documentation before any Kitchen output, making things fairly
annoying.

I believe this is due to version mis-matching between the `:quiet`
flag with docker and kitchen-docker.

Removing the `:quiet` flag from the version check clears up this
output.
