### PR TITLE
Remove ssh tcp check

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -92,7 +92,6 @@ module Kitchen
         logger.info("Waiting for #{state[:hostname]}:#{state[:port]}...") until
           begin
             container_exists?(state)
-            logger.info("Container Exists")
           rescue false
           end
       end

--- a/lib/kitchen/driver/docker_version.rb
+++ b/lib/kitchen/driver/docker_version.rb
@@ -19,6 +19,6 @@ module Kitchen
   module Driver
 
     # Version string for Docker Kitchen driver
-    DOCKER_VERSION = "1.5.1"
+    DOCKER_VERSION = "1.5.0"
   end
 end

--- a/lib/kitchen/driver/docker_version.rb
+++ b/lib/kitchen/driver/docker_version.rb
@@ -19,6 +19,6 @@ module Kitchen
   module Driver
 
     # Version string for Docker Kitchen driver
-    DOCKER_VERSION = "1.5.0"
+    DOCKER_VERSION = "1.5.1"
   end
 end


### PR DESCRIPTION
When the Docker server builds a new container, Kitchen Docker calls the [test_ssh](https://github.com/test-kitchen/test-kitchen/blob/349a728dda458184b167e118213ce8a06e7bd777/lib/kitchen/ssh.rb#L264) method to determine whether or not the container is available. test_ssh makes this determination by attempting a TCP check to the container SSH port.

For networks that put limitations on outgoing TCP ports, this causes Kitchen Docker to not work if you are connecting to a remote Docker server. Such networks may allow the use of an [SSH Proxy](http://backdrift.org/transparent-proxy-with-ssh), in which case everything else works with the Kitchen Docker driver except for the TCP check.

I added an option `:no_ssh_tcp_check` which defaults to `false` and, if set to true, calls the already defined `container_exists?(state)` method to determine if the container is available, instead of the TCP check.

I have been testing this for about two weeks now and it is working well for me.
