### PR TITLE
Add temporary mixlib-shellout constraint.

### DIFF
--- a/kitchen-docker.gemspec
+++ b/kitchen-docker.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'test-kitchen', '>= 1.0.0'
+  spec.add_dependency 'mixlib-shellout', '< 2.1.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Fixes https://github.com/portertech/kitchen-docker/issues/129

Details here: https://github.com/portertech/kitchen-docker/issues/129
