### PR TITLE
Add additional config option - provision_docker_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,22 @@ driver_config:
   require_chef_omnibus: false
 ```
 
+### provision\_docker\_command
+
+Custom Dockerfile command(s) to be run when provisioning the base for the suite containers.
+The difference between this and provision_command is that all provision_command's are prefixed with RUN.
+See https://docs.docker.com/reference/builder/ for potential options.
+
+Examples:
+
+```
+  provision_docker_command:
+    - COPY script.sh /tmp/script.sh
+    - RUN /tmp/script.sh
+```
+
+Useful if you have full script's to run that are painful to add/escape in YAML as provision_command's.
+
 ### use\_cache
 
 This determines if the Docker cache is used when provisioning the base for suite

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -182,11 +182,15 @@ module Kitchen
           RUN echo '#{username} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/#{username}
           RUN chmod 0440 /etc/sudoers.d/#{username}
         eos
-        custom = ''
-        Array(config[:provision_command]).each do |cmd|
-          custom << "RUN #{cmd}\n"
+        custom_docker_cmd = ''
+        Array(config[:provision_docker_command]).each do |cmd|
+          custom_docker_cmd << "#{cmd}\n"
         end
-        [from, platform, base, custom].join("\n")
+        custom_cmd = ''
+        Array(config[:provision_command]).each do |cmd|
+          custom_cmd << "RUN #{cmd}\n"
+        end
+        [from, platform, base, custom_docker_cmd, custom_cmd].join("\n")
       end
 
       def dockerfile


### PR DESCRIPTION
Similar to provision_command but you can specify the Dockerfile command prefix for each.

Opted to go this way to avoid breaking provision_command current functionality.

Includes example use case in README.

This PR supercedes https://github.com/portertech/kitchen-docker/pull/133 and depends on https://github.com/portertech/kitchen-docker/pull/136 for ADD and COPY commands.