### PR TITLE
Suse integration

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -169,7 +169,7 @@ module Kitchen
 	when 'opensuse', 'sles'
 	  <<-eos
             RUN zypper clean
-            RUN zypper install -y sudo openssh which curl
+            RUN zypper --non-interactive install sudo openssh which curl
             RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
             RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''
           eos
@@ -209,48 +209,36 @@ module Kitchen
         username = config[:username]
         password = config[:password]
         public_key = IO.read(config[:public_key])
-#           RUN echo #{username}:#{password} | chpasswd
 
         if config[:platform] == 'opensuse' || config[:platform] == 'sles'
-          basesuse = <<-eos
+          userpw = <<-eos
             RUN if ! getent passwd #{username}; then useradd -d /home/#{username} -m -s /bin/bash #{username}; fi
             RUN echo #{username}:`perl -e 'print crypt("#{password}", "salt")'` | chpasswd -e
-            RUN echo '#{username} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-            RUN mkdir -p /etc/sudoers.d
-            RUN echo '#{username} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/#{username}
-            RUN chmod 0440 /etc/sudoers.d/#{username}
-            RUN [ ! -d /home/#{username}/.ssh ] && mkdir /home/#{username}/.ssh
-            RUN chown -R #{username} /home/#{username}/.ssh
-            RUN chmod 0700 /home/#{username}/.ssh
-            RUN echo '#{public_key}' >> /home/#{username}/.ssh/authorized_keys
-            RUN chown #{username} /home/#{username}/.ssh/authorized_keys
-            RUN chmod 0600 /home/#{username}/.ssh/authorized_keys
           eos
 	else
-          base = <<-eos
+          userpw = <<-eos
             RUN if ! getent passwd #{username}; then useradd -d /home/#{username} -m -s /bin/bash #{username}; fi
             RUN echo #{username}:#{password} | chpasswd
-            RUN echo '#{username} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-            RUN mkdir -p /etc/sudoers.d
-            RUN echo '#{username} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/#{username}
-            RUN chmod 0440 /etc/sudoers.d/#{username}
-            RUN [ ! -d /home/#{username}/.ssh ] && mkdir /home/#{username}/.ssh
-            RUN chown -R #{username} /home/#{username}/.ssh
-            RUN chmod 0700 /home/#{username}/.ssh
-            RUN echo '#{public_key}' >> /home/#{username}/.ssh/authorized_keys
-            RUN chown #{username} /home/#{username}/.ssh/authorized_keys
-            RUN chmod 0600 /home/#{username}/.ssh/authorized_keys
           eos
 	end
+        base = <<-eos
+          RUN echo '#{username} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+          RUN mkdir -p /etc/sudoers.d
+          RUN echo '#{username} ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/#{username}
+          RUN chmod 0440 /etc/sudoers.d/#{username}
+          RUN [ ! -d /home/#{username}/.ssh ] && mkdir /home/#{username}/.ssh
+          RUN chown -R #{username} /home/#{username}/.ssh
+          RUN chmod 0700 /home/#{username}/.ssh
+          RUN echo '#{public_key}' >> /home/#{username}/.ssh/authorized_keys
+          RUN chown #{username} /home/#{username}/.ssh/authorized_keys
+          RUN chmod 0600 /home/#{username}/.ssh/authorized_keys
+        eos
+
         custom = ''
         Array(config[:provision_command]).each do |cmd|
           custom << "RUN #{cmd}\n"
         end
-        if config[:platform] == 'opensuse' || config[:platform] == 'sles'
-          [from, platform, basesuse, custom].join("\n") 
-        else
-          [from, platform, base, custom].join("\n")
-        end
+        [from, platform, userpw, base, custom].join("\n")
       end
 
       def dockerfile


### PR DESCRIPTION
We work mainly with SLES and OpenSUSE OS-Images, so we need to use them as kitchen-docker baseimage for testing purposes.

This PR enables kitchen-docker to work on Suse-Based-Images properly.

Tested with SLES12 and OpenSUSE 13.2
