### PR TITLE
Fixes #164 Enable a single environment variable to be passed

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -204,6 +204,11 @@ module Kitchen
         public_key = IO.read(config[:public_key])
         homedir = username == 'root' ? '/root' : "/home/#{username}"
 
+        custom_env = ''
+        Array(config[:custom_env]).each do |cenv|
+          custom_env << "ENV #{cenv}\n"
+        end
+
         base = <<-eos
           RUN if ! getent passwd #{username}; then \
                 useradd -d #{homedir} -m -s /bin/bash #{username}; \
@@ -226,7 +231,7 @@ module Kitchen
         end
         ssh_key = "RUN echo '#{public_key}' >> #{homedir}/.ssh/authorized_keys"
         # Empty string to ensure the file ends with a newline.
-        [from, platform, base, custom, ssh_key, ''].join("\n")
+        [from, custom_env, platform, base, custom, ssh_key, ''].join("\n")
       end
 
       def dockerfile

--- a/lib/kitchen/driver/docker_version.rb
+++ b/lib/kitchen/driver/docker_version.rb
@@ -19,6 +19,6 @@ module Kitchen
   module Driver
 
     # Version string for Docker Kitchen driver
-    DOCKER_VERSION = "2.3.0"
+    DOCKER_VERSION = "2.4.0"
   end
 end


### PR DESCRIPTION
OK, so this doesn't fix it really, however it does allow a single ENV variable to be set:

```  - name: centos-7.1
    driver_config:
      image: centos:7
      platform: centos
      provision: true
    # Don't use this as it installs EPEL6 on CentOS7
      require_ansible_repo: false
      install_epel_repo: true
      custom_env: container docker
    # Make sure that we swap out the fakesystemd for the real one
      provision_command:
```

results in

```kitchen test
-----> Starting Kitchen (v1.4.2)
-----> Cleaning up any prior instances of <apache2-centos-71>
-----> Destroying <apache2-centos-71>...
       Finished destroying <apache2-centos-71> (0m0.00s).
-----> Testing <apache2-centos-71>
-----> Creating <apache2-centos-71>...
       Sending build context to Docker daemon 57.34 kB
       Sending build context to Docker daemon 
       Step 0 : FROM centos:7
        ---> 0f73ae75014f
       Step 1 : ENV container docker
```

My ruby is decidedly rusty so I've completely failed to be able to parse multiple custom_envs into a hash and then back into the Dockerfile, but I figure this is a good start and I'm willing to accept any suggestions about turning

```
- custom_env:
   - container: docker
   - role: apache
```

into 

```
ENV container docker
ENV role apache
```