### PR TITLE
Added support for tagging the Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,18 @@ Examples:
   build_context: true
 ```
 
+### tag
+
+Pass a repository:tag value for the built Docker image. Defaults to
+kitchen-#{image}. Passing a platform name like centos-7 essentially generates
+a repository:tag value of kitchen-centos:centos7.
+
+Examples:
+
+```yaml
+  tag: "foo:bar"
+```
+
 ## Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -51,6 +51,7 @@ module Kitchen
       default_config :wait_for_sshd, true
       default_config :private_key,   File.join(Dir.pwd, '.kitchen', 'docker_id_rsa')
       default_config :public_key,    File.join(Dir.pwd, '.kitchen', 'docker_id_rsa.pub')
+      default_config :tag,           nil
 
       default_config :use_sudo do |driver|
         !driver.remote_socket?
@@ -254,10 +255,11 @@ module Kitchen
         cmd << " --no-cache" unless config[:use_cache]
         dockerfile_contents = dockerfile
         build_context = config[:build_context] ? '.' : '-'
+        tag = config[:tag] || "kitchen-#{config[:image]}"
         output = Tempfile.create('Dockerfile-kitchen-', Dir.pwd) do |file|
           file.write(dockerfile_contents)
           file.close
-          docker_command("#{cmd} -f #{file.path} #{build_context}", :input => dockerfile_contents)
+          docker_command("#{cmd} -t #{tag} -f #{file.path} #{build_context}", :input => dockerfile_contents)
         end
         parse_image_id(output)
       end


### PR DESCRIPTION
Instead of using `<none>:<none>`, a `repository:tag` is automatically generated to make some sense out of `docker images`. It isn't very useful without taking anti-cache busting measures, such as declaring `public_key` and `private_key` to point to static files, but it is very useful for using custom dockerfiles while tagging the Docker builds.

It looks like this:

```bash
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
foo                 bar                 83fb2f30efd1        18 minutes ago      275.2 MB
kitchen-centos      centos6             d3c4fd4b9a5e        24 minutes ago      275.2 MB
centos              centos6             72703a0520b7        4 weeks ago         190.6 MB
```

Where foo:bar = custom value, kitchen-centos:centos7 = default value.