### PR TITLE
add sudo detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ The default value depends on the type of socket being used. For local sockets, t
 
 This should be set to `false` if you're using boot2docker, as every command passed into the VM runs as root by default.
 
+### sudo\_detection
+
+This determines if Docker command initialization should also be tried with the the opposite `use_sudo` command when the first attempt failed.
+
+The default value is `true`.
+
 ### remove\_images
 
 This determines if images are automatically removed when the suite container is


### PR DESCRIPTION
This PR should make it easier to use `kitchen-docker`.

I'm running Docker without `sudo` and was wondering why I get a runtime error with the message

[`You must first install the Docker CLI tool http://www.docker.io/gettingstarted/`](https://github.com/portertech/kitchen-docker/blob/master/lib/kitchen/driver/docker.rb#L77)

Which is definitely misleading, because I knew I had Docker installed (but this issue isn't handled here).

Anyway, I changed the behaviour a bit, so if you are trying to work with `kitchen-docker` at first a try with the defined option will be used (ie. with `true` [if you develop local](https://github.com/portertech/kitchen-docker/blob/master/lib/kitchen/driver/docker.rb#L56)). If that command failed we try it with the opposite option and set it the exact this when the command succeeded this time (ie. `false`).

If someone rather want to keep the default, you can disable this behaviour by setting `sudo_detection` to `false.
