### PR TITLE
quote bugfix when `public_key` configured

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -241,7 +241,7 @@ module Kitchen
         Array(config[:provision_command]).each do |cmd|
           custom << "RUN #{cmd}\n"
         end
-        ssh_key = "RUN echo '#{public_key}' >> #{homedir}/.ssh/authorized_keys"
+        ssh_key = "RUN echo \"#{public_key}\" >> #{homedir}/.ssh/authorized_keys"
         # Empty string to ensure the file ends with a newline.
         [from, env_variables, platform, base, custom, ssh_key, ''].join("\n")
       end


### PR DESCRIPTION
This should help if you see something like this after setting the `public_key` config:

```
/bin/sh: 1: Syntax error: Unterminated quoted string
```