### PR TITLE
support passing in '-e' flags - fixes systemd init

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -313,6 +313,7 @@ module Kitchen
         cmd << " -c #{config[:cpu]}" if config[:cpu]
         cmd << " -e http_proxy=#{config[:http_proxy]}" if config[:http_proxy]
         cmd << " -e https_proxy=#{config[:https_proxy]}" if config[:https_proxy]
+        cmd << " -e #{config[:eflags]}" if config[:eflags]
         cmd << " --privileged" if config[:privileged]
         Array(config[:cap_add]).each {|cap| cmd << " --cap-add=#{cap}"} if config[:cap_add]
         Array(config[:cap_drop]).each {|cap| cmd << " --cap-drop=#{cap}"} if config[:cap_drop]


### PR DESCRIPTION
This commit allows for passing in '-e' flags in the driver config. Passing in an '-e' flag for container=docker allows systems which use systemd as init - CentOS7 - to start systemd within the container. This allows for testing when cookbooks install and start services on servers which use systemd as their init system. This can be verified using docker image: centos:7 , and the following driver_config:

    driver_config:
      privileged: true
      run_command: /usr/sbin/init
      volume:
        - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
      provision_command: systemctl enable sshd.service
      eflags: container=docker

BTW - let me know if you prefer a different implementation, and I'll modify the PR to suit your expectations.