### PR TITLE
Require Tempfile

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -19,6 +19,7 @@ require 'json'
 require 'securerandom'
 require 'uri'
 require 'net/ssh'
+require 'tempfile'
 require File.join(File.dirname(__FILE__), 'docker', 'erb')
 
 module Kitchen


### PR DESCRIPTION
Sure, lots of other things use it, so _probably_ it's been required, but apparently, if you use the test-kitchen rake tasks, you can get here without it having been required.

Also, it's just good hygiene.