### PR TITLE
Add an environment variable to allow override of the default value for use_sudo

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -53,7 +53,11 @@ module Kitchen
       default_config :public_key,    File.join(Dir.pwd, '.kitchen', 'docker_id_rsa.pub')
 
       default_config :use_sudo do |driver|
-        !driver.remote_socket?
+        if ENV.key?('KITCHEN_DOCKER_USE_SUDO')
+          !!(ENV['KITCHEN_DOCKER_USE_SUDO'] =~ /^(t(rue)?|y(es)?)?$/)
+        else
+          !driver.remote_socket?
+        end
       end
 
       default_config :image do |driver|


### PR DESCRIPTION
I’d like a way to override the default value of the `use_sudo` configuration option (without editing all of my `.kitchen.yml` files). This seemed the logical choice.

Rationale: I’m using the beta of Docker for MacOS, which uses a local socket, but does not require sudo. Worse, running docker via sudo fails in my beta installation.

I don’t want to hardcode my need for the value to be false into (all of) `.kitchen.yml` files, since that may affect others on the team. 