### PR TITLE
Support tmpfs mounts without requiring privileged mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,22 @@ Examples:
   - /srv
 ```
 
+### tmpfs
+
+Mount a tmpfs inside of the container without requiring privileged mode
+
+Examples:
+
+```yaml
+  tmpfs: /run:rw,noexec,nosuid,size=65536k
+```
+
+```yaml
+  tmpfs:
+  - /run/lock
+  - /tmp
+```
+
 ### volumes\_from
 
 Mount volumes managed by other containers.

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -307,6 +307,7 @@ module Kitchen
         Array(config[:volumes_from]).each {|container| cmd << " --volumes-from #{container}"}
         Array(config[:links]).each {|link| cmd << " --link #{link}"}
         Array(config[:devices]).each {|device| cmd << " --device #{device}"}
+        Array(config[:tmpfs]).each {|tmpfs| cmd << " --tmpfs #{tmpfs}"}
         cmd << " --name #{config[:instance_name]}" if config[:instance_name]
         cmd << " -P" if config[:publish_all]
         cmd << " -h #{config[:hostname]}" if config[:hostname]


### PR DESCRIPTION
@portertech @coderanger for review

This allows mounting tmpfs inside of a docker container, using docker's "--tmpfs" flag.

My use case is that I want to be able to mount tmpfs without needed to run in privileged mode.

In particular, tmpfs is useful with the overlayfs driver where unix domain sockets won't work on overlayfs at all. This workaround allows you to make the usual suspects for unix domain sockets to be tmpfs.