### PR TITLE
Adding options driver_config to allow any docker arguments to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,18 @@ Examples:
   build_context: true
 ```
 
+### options
+
+Any additional docker command line options
+
+Examples:
+
+```yaml
+  options:
+    - "--ip=172.10.0.10"
+    - "--net=bridge"
+```
+
 ## Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -319,6 +319,7 @@ module Kitchen
         Array(config[:cap_add]).each {|cap| cmd << " --cap-add=#{cap}"} if config[:cap_add]
         Array(config[:cap_drop]).each {|cap| cmd << " --cap-drop=#{cap}"} if config[:cap_drop]
         Array(config[:security_opt]).each {|opt| cmd << " --security-opt=#{opt}"} if config[:security_opt]
+        Array(config[:options]).each {|option| cmd << " #{option}"}
         cmd << " #{image_id} #{config[:run_command]}"
         cmd
       end


### PR DESCRIPTION
I had a use case where i needed to set a static known IP to a container while testing.
This adds extra docker config to allow any docker arguments to be used