### PR TITLE
File path with space 

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -281,7 +281,7 @@ module Kitchen
         output = begin
           file.write(dockerfile)
           file.close
-          docker_command("#{cmd} -f #{file.path} #{build_context}", :input => dockerfile_contents)
+          docker_command("#{cmd} -f \"#{file.path}\" #{build_context}", :input => dockerfile_contents)
         ensure
           file.close unless file.closed?
           file.unlink


### PR DESCRIPTION
By adding quote around file.path, kitchen docker still work if the current project path contains spaces.