### PR TITLE
env container=docker for debians, ext #192

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -187,6 +187,7 @@ module Kitchen
           eos
           packages = <<-eos
             ENV DEBIAN_FRONTEND noninteractive
+            ENV container docker
             RUN apt-get update
             RUN apt-get install -y sudo openssh-server curl lsb-release
           eos


### PR DESCRIPTION
When running /sbin/init from systemd in debian:stretch (recent, unable
to determine since when), it is necessary to include the enviroment
variable container=docker in the Dockerfiles. This is essentially the
same as for recent CentOSes as previously fixed in #192.

Tests with ubuntu-14.04 have shown no hurts and I strongly suspect the
same for other debian-based images.

	modified:   lib/kitchen/driver/docker.rb