### PR TITLE
Fix Gentoo support

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -233,7 +233,7 @@ module Kitchen
           eos
         when 'gentoo'
           <<-eos
-            RUN emerge sync
+            RUN emerge --sync
             RUN emerge net-misc/openssh app-admin/sudo
             RUN ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key


### PR DESCRIPTION
`emerge sync` is obsolete and already removed as valid sync method.
`emerge --sync` has to be used and is implemented in docker.rb now.