### PR TITLE
Respect transport forward_agent true

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,15 @@ Sets the command used to run the suite container.
 
 The default value is `/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid`.
 
+With
+
+```yaml
+trasport:
+  forward_agent: true
+```
+
+then `-o AllowAgentForwarding` is appended for you to `run\_command`.
+
 Examples:
 
 ```yaml

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -42,11 +42,13 @@ module Kitchen
       default_config :security_opt,  nil
       default_config :use_cache,     true
       default_config :remove_images, false
-      default_config :run_command do |driver|
-        '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes ' +
-          '-o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid' +
-          (driver.instance.transport.options.key?(:forward_agent) ? '-o AllowAgentForwarding=yes' : '')
-      end
+      default_config :run_command, '/usr/sbin/sshd -D ' +
+                                   '-o UseDNS=no ' +
+                                   '-o UsePAM=no ' +
+                                   '-o PasswordAuthentication=yes ' +
+                                   '-o UsePrivilegeSeparation=no ' +
+                                   '-o PidFile=/tmp/sshd.pid ' +
+                                   '-o AllowAgentForwarding=yes'
       default_config :username,      'kitchen'
       default_config :tls,           false
       default_config :tls_verify,    false

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -43,7 +43,8 @@ module Kitchen
       default_config :use_cache,     true
       default_config :remove_images, false
       default_config :run_command,   '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes ' +
-                                     '-o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid'
+                                     '-o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid' +
+                                     (instance.transport.options.key?(:forward_agent) ? '-o AllowAgentForwarding=yes' : '')
       default_config :username,      'kitchen'
       default_config :tls,           false
       default_config :tls_verify,    false

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -42,9 +42,11 @@ module Kitchen
       default_config :security_opt,  nil
       default_config :use_cache,     true
       default_config :remove_images, false
-      default_config :run_command,   '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes ' +
-                                     '-o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid' +
-                                     (instance.transport.options.key?(:forward_agent) ? '-o AllowAgentForwarding=yes' : '')
+      default_config :run_command do |driver|
+        '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes ' +
+          '-o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid' +
+          (driver.instance.transport.options.key?(:forward_agent) ? '-o AllowAgentForwarding=yes' : '')
+      end
       default_config :username,      'kitchen'
       default_config :tls,           false
       default_config :tls_verify,    false


### PR DESCRIPTION
## Motivation

If you wanted to forward an ssh agent into the container you had to
add `-o AllowAgentForwarding` to `run\_command` _and_ set
`forward_agent: true` in your `.kitchen.yml`. It seems that if you've
indicated that you'd like to forward your agent we should automatically
allow it on the sshd side without further configuration.

Closes https://github.com/test-kitchen/kitchen-docker/issues/232
