### PR TITLE
added ssh_host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,21 @@ Examples:
     net: br3
 ```
 
+### ssh_host
+
+Support for playing nicely with SSH transport's `ssh_gateway` option. If
+set, kitchen ssh will attempt to connect to the SSH daemon running on the
+specified host. This allows for running tests against remote docker engines
+without the need to open additional ports on the remote host. Usually you will
+want to set this to `localhost` when used in conjunction with SSH
+transport's `ssh_gateway` option.
+
+Examples:
+
+```yaml
+  ssh_host: localhost
+```
+
 ## Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -56,6 +56,7 @@ module Kitchen
       default_config :public_key,    File.join(Dir.pwd, '.kitchen', 'docker_id_rsa.pub')
       default_config :build_options, nil
       default_config :run_options,   nil
+      default_config :ssh_host,      nil
 
       default_config :use_sudo do |driver|
         !driver.remote_socket?
@@ -121,7 +122,7 @@ module Kitchen
         state[:ssh_key] = config[:private_key]
         state[:image_id] = build_image(state) unless state[:image_id]
         state[:container_id] = run_container(state) unless state[:container_id]
-        state[:hostname] = remote_socket? ? socket_uri.host : 'localhost'
+        state[:hostname] = config[:ssh_host] || (remote_socket? ? socket_uri.host : 'localhost')
         state[:port] = container_ssh_port(state)
         if config[:wait_for_sshd]
           instance.transport.connection(state) do |conn|


### PR DESCRIPTION
Support for playing nicely with SSH transport's `ssh_gateway` option. If
set, kitchen ssh will attempt to connect to the SSH daemon running on the
specified host. This allows for running tests against remote docker engines
without the need to open additional ports on the remote host. Usually you will
want to set this to `localhost` when used in conjunction with SSH
transport's `ssh_gateway` option.
