### PR TITLE
Use relative paths when passing -f Dockerfile

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -307,7 +307,7 @@ module Kitchen
         output = begin
           file.write(dockerfile)
           file.close
-          docker_command("#{cmd} -f #{Shellwords.escape(file.path)} #{build_context}", :input => dockerfile_contents)
+          docker_command("#{cmd} -f #{Shellwords.escape(dockerfile_path(file))} #{build_context}", :input => dockerfile_contents)
         ensure
           file.close unless file.closed?
           file.unlink
@@ -408,6 +408,10 @@ module Kitchen
         when Hash
           config.map {|k, v| Array(v).map {|c| "--#{k}=#{Shellwords.escape(c)}" }.join(' ') }.join(' ')
         end
+      end
+
+      def dockerfile_path(file)
+        config[:build_context] ? Pathname.new(file.path).relative_path_from(Pathname.pwd).to_s : file.path
       end
 
     end


### PR DESCRIPTION
This change resolves an error using kitchen-docker where Docker refuses to acknowledge that a build context of `.` includes the Dockerfile when the Dockerfile is given with an absolute path. Here's an example of the error output:

```
$ kitchen converge app-worker-trusty
-----> Starting Kitchen (v1.14.2)
-----> Creating <app-worker-trusty>...
       unable to prepare context: The Dockerfile (/Users/andre.arko/chef/Dockerfile-kitchen20161209-24579-1pvw8h7) must be within the build context (.)
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #create action: [Expected process to exit with [0], but received '1'
---- Begin output of docker -H unix:///var/run/docker.sock build -f /Users/andre.arko/chef/Dockerfile-kitchen20161209-24579-1pvw8h7 . ----
STDOUT:
STDERR: unable to prepare context: The Dockerfile (/Users/andre.arko/chef/Dockerfile-kitchen20161209-24579-1pvw8h7) must be within the build context (.)
---- End output of docker -H unix:///var/run/docker.sock build -f /Users/andre.arko/chef/Dockerfile-kitchen20161209-24579-1pvw8h7 . ----
Ran docker -H unix:///var/run/docker.sock build -f /Users/andre.arko/chef/Dockerfile-kitchen20161209-24579-1pvw8h7 . returned 1] on app-worker-trusty
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

After this change is applied:

```
$  kitchen create app-worker-trusty
-----> Starting Kitchen (v1.14.2)
-----> Creating <app-worker-trusty>...
Sending build context to Docker daemon 307.3 MB57.1 kB
       Step 1 : FROM ubuntu:trusty-20151021
       trusty-20151021: Pulling from library/ubuntu
[...]
```