### PR TITLE
Support alpine platform

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -245,6 +245,14 @@ module Kitchen
             RUN ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
           eos
+        when 'alpine'
+          <<-eos
+            RUN echo "@edge http://dl-3.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+            RUN apk --update add openssh curl sudo bash shadow@edge
+            RUN echo > /etc/default/useradd
+            RUN ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
+            RUN ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
+          eos
         else
           raise ActionFailed,
           "Unknown platform '#{config[:platform]}'"


### PR DESCRIPTION
Hi,

First thank you for kitchen-docker, This PR adds support for Alpine linux as a platform.
I read the history of PR #190. I understand that chef does not yet support Alpine.
Here is a working [example](https://github.com/AutomationWithAnsible/ansible-usermanage/blob/master/.kitchen.yml) that works with Anisble provisioner and Serverspec verifier. 

Regards,




