### PR TITLE
Add ability to use ~ in public and private key path

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -57,6 +57,9 @@ module Kitchen
       default_config :build_options, nil
       default_config :run_options,   nil
 
+      expand_path_for :private_key
+      expand_path_for :public_key
+
       default_config :use_sudo do |driver|
         !driver.remote_socket?
       end


### PR DESCRIPTION
Having the ability to use the `~` in `public_key` and `private_key`
which gets evaluated to the current users home directory can be useful
in preventing several different images from being created. Each time
kitchen-docker runs it looks for existing SSH keys and will use them.
When using Docker cache this means no new images is created. If no keys
are found they are randomly generated and as a result, a new image is
created.