### PR TITLE
pre_create_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,18 @@ Examples:
     net: br3
 ```
 
+### pre_create_command
+
+A shell command which is run locally before creating the container.
+Used to prepare the build environment (e.g. to generate files
+to be copied in the build process or used in converge stage).
+
+Examples:
+
+```yaml
+  pre_create_command: ./my_shell_script.sh
+```
+
 ## Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -116,6 +116,7 @@ module Kitchen
       end
 
       def create(state)
+        pre_create_command
         generate_keys
         state[:username] = config[:username]
         state[:ssh_key] = config[:private_key]
@@ -283,6 +284,16 @@ module Kitchen
           ERB.new(template).result(context.get_binding)
         else
           build_dockerfile
+        end
+      end
+
+      def pre_create_command
+        if config[:pre_create_command]
+          system(config[:pre_create_command])
+          if $?.exitstatus.nonzero?
+            raise ActionFailed,
+              "pre_create_command '#{config[:pre_create_command]}' failed to execute (exit status #{$?.exitstatus})"
+          end
         end
       end
 


### PR DESCRIPTION
kitchen-vagrant allows to run shell command prior to the creation of the VM. Here's an adaptation of its pre_create_command option for kitchen-docker.