### PR TITLE
Fix ssh_host key generation failure if file already exists

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -217,8 +217,8 @@ module Kitchen
             ENV container docker
             RUN yum clean all
             RUN yum install -y sudo openssh-server openssh-clients which curl
-            RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
-            RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''
+            RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
+            RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''
           eos
         when 'arch'
           # See https://bugs.archlinux.org/task/47052 for why we
@@ -227,23 +227,23 @@ module Kitchen
             RUN pacman --noconfirm -Sy archlinux-keyring
             RUN pacman-db-upgrade
             RUN pacman --noconfirm -Sy openssl openssh sudo curl
-            RUN ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
-            RUN ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
+            RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
+            RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
             RUN echo >/etc/security/limits.conf
           eos
         when 'gentoo'
           <<-eos
             RUN emerge --sync
             RUN emerge net-misc/openssh app-admin/sudo
-            RUN ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
-            RUN ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
+            RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
+            RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
           eos
         when 'gentoo-paludis'
           <<-eos
             RUN cave sync
             RUN cave resolve -zx net-misc/openssh app-admin/sudo
-            RUN ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
-            RUN ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
+            RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
+            RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
           eos
         else
           raise ActionFailed,


### PR DESCRIPTION
`/etc/ssh/ssh_host_*` keys are needed for SSH server to work properly, that's why you generate them.

However if user has pre-baked Docker images with already configured SSH server or where keys already exist, - he'll get the following error log: 
```sh
Generating public/private rsa key pair.
       /etc/ssh/ssh_host_rsa_key already exists.
       Overwrite (y/n)? The command '/bin/sh -c ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''' returned a non-zero code: 1
 ```
![](https://i.imgur.com/gfac4Z5.png)

With this change we don't generate SSH keys if they already exist.

----

It's possible to specify custom [`Dockerfile`](https://github.com/test-kitchen/kitchen-docker/blob/master/test/Dockerfile), but I think this PR brings safer defaults for everyone.