### PR TITLE
Add -E /tmp/sshd.log to default run_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The default value is `false`.
 
 Sets the command used to run the suite container.
 
-The default value is `/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid`.
+The default value is `/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid -E /tmp/sshd.log`.
 
 Examples:
 

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -43,7 +43,8 @@ module Kitchen
       default_config :use_cache,     true
       default_config :remove_images, false
       default_config :run_command,   '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes ' +
-                                     '-o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid'
+                                     '-o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid ' +
+                                     '-E /tmp/sshd.log'
       default_config :username,      'kitchen'
       default_config :tls,           false
       default_config :tls_verify,    false


### PR DESCRIPTION
The logs from sshd don't seem to be saved anywhere; this makes them visible.