### PR TITLE
added dns-search option to docker driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,24 @@ Examples:
   - 8.8.8.8
   - 8.8.4.4
 ```
+
+### dns\_search
+
+Adjusts `resolv.conf` to use the search domains specified. Otherwise use
+Dockers defaults.
+
+Examples:
+
+```yaml
+  dns_search: example.com
+```
+
+```yaml
+  dns_search:
+  - foo.example.com
+  - bar.example.com
+```
+
 ### http\_proxy
 
 Sets an http proxy for the suite container using the `http_proxy` environment variable.

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -335,6 +335,7 @@ module Kitchen
         cmd = "run -d -p 22"
         Array(config[:forward]).each {|port| cmd << " -p #{port}"}
         Array(config[:dns]).each {|dns| cmd << " --dns #{dns}"}
+        Array(config[:dns_search]).each {|dns_search| cmd << " --dns-search #{dns_search}"}
         Array(config[:add_host]).each {|host, ip| cmd << " --add-host=#{host}:#{ip}"}
         Array(config[:volume]).each {|volume| cmd << " -v #{volume}"}
         Array(config[:volumes_from]).each {|container| cmd << " --volumes-from #{container}"}


### PR DESCRIPTION
Adding dns-search option as docker parameter (docker run ... --dns-search foo.bar --dns-search example.com ...)