### PR TITLE
Avoid creating many intermediate containers 

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -15,3 +15,4 @@ RUN yum clean all && \
     chmod 0600 /home/<%= @username %>/.ssh/authorized_keys && \
     curl -L https://www.chef.io/chef/install.sh | bash && \
     echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys && \
+    true

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,17 +1,17 @@
 FROM centos:6
-RUN yum clean all
-RUN yum install -y sudo openssh-server openssh-clients which curl htop
-RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
-RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
-RUN mkdir -p /var/run/sshd
-RUN useradd -d /home/<%= @username %> -m -s /bin/bash <%= @username %>
-RUN echo <%= "#{@username}:#{@password}" %> | chpasswd
-RUN echo '<%= @username %> ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-RUN mkdir -p /home/<%= @username %>/.ssh
-RUN chown -R <%= @username %> /home/<%= @username %>/.ssh
-RUN chmod 0700 /home/<%= @username %>/.ssh
-RUN touch /home/<%= @username %>/.ssh/authorized_keys
-RUN chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys
-RUN chmod 0600 /home/<%= @username %>/.ssh/authorized_keys
-RUN curl -L https://www.chef.io/chef/install.sh | bash
-RUN echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys
+RUN yum clean all && \
+    yum install -y sudo openssh-server openssh-clients which curl htop && \
+    ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key && \
+    ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key && \
+    mkdir -p /var/run/sshd && \
+    useradd -d /home/<%= @username %> -m -s /bin/bash <%= @username %> && \
+    echo <%= "#{@username}:#{@password}" %> | chpasswd && \
+    echo '<%= @username %> ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    mkdir -p /home/<%= @username %>/.ssh && \
+    chown -R <%= @username %> /home/<%= @username %>/.ssh && \
+    chmod 0700 /home/<%= @username %>/.ssh && \
+    touch /home/<%= @username %>/.ssh/authorized_keys && \
+    chown <%= @username %> /home/<%= @username %>/.ssh/authorized_keys && \
+    chmod 0600 /home/<%= @username %>/.ssh/authorized_keys && \
+    curl -L https://www.chef.io/chef/install.sh | bash && \
+    echo '<%= IO.read(@public_key).strip %>' >> /home/<%= @username %>/.ssh/authorized_keys && \


### PR DESCRIPTION
Provisioning of the test container not always happens from the cache and during every RUN statement, an intermediate container is created. 

To speed up things, I suggest to keep all commands under a single RUN statement. 

```
       Removing intermediate container 7b31500263be
       Step 8 : RUN echo "kitchen ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
        ---> Running in f94b94083700
        ---> 4f7df4680341
       Removing intermediate container f94b94083700
       Step 9 : RUN echo "Defaults !requiretty" >> /etc/sudoers
        ---> Running in fe4808ab9198
        ---> 1a2824561b0b
       Removing intermediate container fe4808ab9198
       Step 10 : RUN mkdir -p /home/kitchen/.ssh
        ---> Running in b9f6dbf11c9f
        ---> 555d1694679e
```