### PR TITLE
Add add_files section to the Docker driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.gem
 *.rbc
+*.swp
+*.swo
 .bundle
 .config
 .yardoc

--- a/README.md
+++ b/README.md
@@ -161,6 +161,20 @@ working upstart.
 
 The default value is `true`.
 
+### add\_files
+
+Simple mapping to the Docker `ADD ...` command. This is a list of files that
+you want to add to your container _before_ the `provision_command`s are
+executed. This only works if `build_context` is set!
+
+Examples:
+
+```yaml
+    add_files:
+      - /tests/setup.sh /tmp/setup.sh
+      - /tests/ssl/ /tmp/ssl/
+```
+
 ### provision\_command
 
 Custom command(s) to be run when provisioning the base for the suite containers.

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -44,6 +44,7 @@ module Kitchen
       default_config :remove_images, false
       default_config :run_command,   '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes ' +
                                      '-o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid'
+      default_config :add_files,     []
       default_config :username,      'kitchen'
       default_config :tls,           false
       default_config :tls_verify,    false
@@ -275,9 +276,14 @@ module Kitchen
           RUN chmod 0600 #{homedir}/.ssh/authorized_keys
         eos
         custom = ''
+        Array(config[:add_files]).each do |file|
+          custom << "ADD #{file}\n"
+        end
         Array(config[:provision_command]).each do |cmd|
           custom << "RUN #{cmd}\n"
         end
+
+
         ssh_key = "RUN echo #{Shellwords.escape(public_key)} >> #{homedir}/.ssh/authorized_keys"
         # Empty string to ensure the file ends with a newline.
         [from, env_variables, platform, base, custom, ssh_key, ''].join("\n")


### PR DESCRIPTION
So this works basically -- not sure if you need me to add tests or not. I didn't see a ton of tests in there already.

```
  suites:
    - name: default
      driver:
        add_files:
          # Note, we support both Puppet 3 and 5 here..
          - /smoketests/csr_attributes/base.yaml /etc/puppet/csr_attributes.yaml
          - /smoketests/csr_attributes/base.yaml /opt/puppetlabs/puppet/csr_attributes.yaml
```

```
        ---> Using cache
        ---> c63971e255bc
       Step 17/20 : ADD /smoketests/csr_attributes/base.yaml /etc/puppet/csr_attributes.yaml
        ---> adbcf56f8457
       Step 18/20 : ADD /smoketests/csr_attributes/base.yaml /opt/puppetlabs/puppet/csr_attributes.yaml
        ---> 30452ac3c7cc
```