### PR TITLE
Add use_internal_docker_network feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,19 @@ Examples:
     net: br3
 ```
 
+### use_internal_docker_network
+
+If you want to use kitchen-docker from within another Docker container you'll
+need to set this to true. When set to true uses port 22 as the SSH port and
+the IP of the container that chef is going to run in as the hostname so that
+you can connect to it over SSH from within another Docker container.
+
+Examples:
+
+```yaml
+  use_internal_docker_network: true
+```
+
 ## Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -56,6 +56,7 @@ module Kitchen
       default_config :public_key,    File.join(Dir.pwd, '.kitchen', 'docker_id_rsa.pub')
       default_config :build_options, nil
       default_config :run_options,   nil
+      default_config :use_internal_docker_network, false
 
       default_config :use_sudo do |driver|
         !driver.remote_socket?
@@ -121,7 +122,12 @@ module Kitchen
         state[:ssh_key] = config[:private_key]
         state[:image_id] = build_image(state) unless state[:image_id]
         state[:container_id] = run_container(state) unless state[:container_id]
-        state[:hostname] = remote_socket? ? socket_uri.host : 'localhost'
+        state[:hostname] = 'localhost'
+        if remote_socket?
+          state[:hostname] = socket_uri.host
+        elsif config[:use_internal_docker_network]
+          state[:hostname] = container_ip(state)
+        end
         state[:port] = container_ssh_port(state)
         if config[:wait_for_sshd]
           instance.transport.connection(state) do |conn|
@@ -379,11 +385,25 @@ module Kitchen
 
       def container_ssh_port(state)
         begin
+          if config[:use_internal_docker_network]
+            return 22
+          end
           output = docker_command("port #{state[:container_id]} 22/tcp")
           parse_container_ssh_port(output)
         rescue
           raise ActionFailed,
           'Docker reports container has no ssh port mapped'
+        end
+      end
+
+      def container_ip(state)
+        begin
+          cmd = "inspect --format '{{ .NetworkSettings.IPAddress }}'"
+          cmd << " #{state[:container_id]}"
+          docker_command(cmd)
+        rescue
+          raise ActionFailed,
+          'Error getting internal IP of Docker container'
         end
       end
 


### PR DESCRIPTION
Hello,

I've been trying to use kitchen-docker from within another Docker container but by default it tries to SSH into localhost and use the mapped port which doesn't work from within a Docker container.

This patch adds an option called `use_internal_docker_network` which if set to true switches the port to 22 rather than the port that its mapped to on the host, and uses the IP of the container rather than localhost, enabling kitchen-docker to SSH into the container and run chef from within another Docker container.