### PR TITLE
Add support for "alpine" as platform

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -271,19 +271,19 @@ module Kitchen
 
         case config[:platform]
         # alpine useradd throws warning, so use adduser instead
-        when 'alpine'
-          user = <<-eos
-            RUN if ! getent passwd #{username}; then \
-                  adduser -h #{homedir} -s /bin/bash -D #{username}; \
-                fi
-          eos
-        else
-          user = <<-eos
-            RUN if ! getent passwd #{username}; then \
-                  useradd -d #{homedir} -m -s /bin/bash -p '*' #{username}; \
-                fi
-          eos
-        end
+        # when 'alpine'
+        #   user = <<-eos
+        #     RUN if ! getent passwd #{username}; then \
+        #           adduser -h #{homedir} -s /bin/bash -D #{username}; \
+        #         fi
+        #   eos
+        # else
+        user = <<-eos
+          RUN if ! getent passwd #{username}; then \
+                useradd -d #{homedir} -m -s /bin/bash -p '*' #{username}; \
+              fi
+        eos
+        # end
 
         base = <<-eos
           RUN echo "#{username} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -254,7 +254,7 @@ module Kitchen
           eos
         when 'alpine'
           <<-eos
-            RUN apk add --no-cache busybox openssh sudo
+            RUN apk add --no-cache busybox openssh sudo shadow
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
             RUN [ -f "/etc/ssh/ssh_host_ecdsa_key" ] || ssh-keygen -A -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -269,7 +269,7 @@ module Kitchen
         public_key = IO.read(config[:public_key]).strip
         homedir = username == 'root' ? '/root' : "/home/#{username}"
 
-        case platform
+        case config[:platform]
         # alpine useradd throws warning, so use adduser instead
         when 'alpine'
           user = <<-eos
@@ -284,6 +284,7 @@ module Kitchen
                 fi
           eos
         end
+
         base = <<-eos
           RUN echo "#{username} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
           RUN echo "Defaults !requiretty" >> /etc/sudoers

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -254,7 +254,7 @@ module Kitchen
           eos
         when 'alpine'
           <<-eos
-            RUN apk add --no-cache busybox openssh sudo shadow bash
+            RUN apk add --no-cache busybox openssh sudo
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
             RUN [ -f "/etc/ssh/ssh_host_ecdsa_key" ] || ssh-keygen -A -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key
@@ -274,7 +274,7 @@ module Kitchen
         when 'alpine'
           user = <<-eos
             RUN if ! getent passwd #{username}; then \
-                  adduser -g "kitchen user" -h #{homedir} -s /bin/bash -D #{username}; \
+                  adduser -g "kitchen user" -h #{homedir} -s /bin/sh -D #{username}; \
                 fi
           eos
         else

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -254,7 +254,7 @@ module Kitchen
           eos
         when 'alpine'
           <<-eos
-            RUN apk add --no-cache busybox openssh sudo
+            RUN apk add --no-cache busybox openssh sudo bash
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
             RUN [ -f "/etc/ssh/ssh_host_ecdsa_key" ] || ssh-keygen -A -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key
@@ -274,7 +274,7 @@ module Kitchen
         when 'alpine'
           user = <<-eos
             RUN if ! getent passwd #{username}; then \
-                  adduser -h #{homedir} -s /bin/sh -D #{username}; \
+                  adduser -h #{homedir} -s /bin/bash -D #{username}; \
                 fi
           eos
         else

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -274,8 +274,7 @@ module Kitchen
         when 'alpine'
           user = <<-eos
             RUN if ! getent passwd #{username}; then \
-                  adduser -g "kitchen user" -h #{homedir} -s /bin/ash #{username}; \
-                  usermod -p * #{username}; \
+                  adduser -g "kitchen user" -h #{homedir} -s /bin/ash #{username} && usermod -p * #{username}; \
                 fi
           eos
         else

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -254,7 +254,7 @@ module Kitchen
           eos
         when 'alpine'
           <<-eos
-            RUN apk add --no-cache busybox openssh shadow sudo
+            RUN apk add --no-cache busybox openssh shadow sudo bash
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
             RUN [ -f "/etc/ssh/ssh_host_ecdsa_key" ] || ssh-keygen -A -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -269,7 +269,7 @@ module Kitchen
         public_key = IO.read(config[:public_key]).strip
         homedir = username == 'root' ? '/root' : "/home/#{username}"
 
-        case config[:platform]
+        # case config[:platform]
         # alpine useradd throws warning, so use adduser instead
         # when 'alpine'
         #   user = <<-eos

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -254,7 +254,7 @@ module Kitchen
           eos
         when 'alpine'
           <<-eos
-            RUN apk add --no-cache busybox openssh sudo shadow bash
+            RUN apk add --no-cache busybox openssh sudo shadow
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
             RUN [ -f "/etc/ssh/ssh_host_ecdsa_key" ] || ssh-keygen -A -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key
@@ -274,7 +274,8 @@ module Kitchen
         when 'alpine'
           user = <<-eos
             RUN if ! getent passwd #{username}; then \
-                  adduser -g "kitchen user" -h #{homedir} -s /bin/bash -D #{username}; \
+                  adduser -g "kitchen user" -h #{homedir} -s /bin/ash -D #{username}; \
+                  usermod -p * #{username}; \
                 fi
           eos
         else

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -254,7 +254,7 @@ module Kitchen
           eos
         when 'alpine'
           <<-eos
-            RUN apk add --no-cache busybox openssh sudo bash
+            RUN apk add --no-cache busybox openssh sudo shadow bash
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
             RUN [ -f "/etc/ssh/ssh_host_ecdsa_key" ] || ssh-keygen -A -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -254,7 +254,7 @@ module Kitchen
           eos
         when 'alpine'
           <<-eos
-            RUN apk add --no-cache busybox openssh sudo shadow
+            RUN apk add --no-cache busybox openssh sudo shadow bash
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
             RUN [ -f "/etc/ssh/ssh_host_ecdsa_key" ] || ssh-keygen -A -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key
@@ -274,7 +274,7 @@ module Kitchen
         when 'alpine'
           user = <<-eos
             RUN if ! getent passwd #{username}; then \
-                  adduser -g "kitchen user" -h #{homedir} -s /bin/sh -D #{username}; \
+                  adduser -g "kitchen user" -h #{homedir} -s /bin/bash -D #{username}; \
                 fi
           eos
         else

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -274,7 +274,7 @@ module Kitchen
         when 'alpine'
           user = <<-eos
             RUN if ! getent passwd #{username}; then \
-                  adduser -g "kitchen user" -h #{homedir} -s /bin/ash #{username} && usermod -p * #{username}; \
+                  adduser -g "kitchen user" -h #{homedir} -s /bin/ash -D #{username} && usermod -p '*' #{username}; \
                 fi
           eos
         else

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -274,7 +274,7 @@ module Kitchen
         when 'alpine'
           user = <<-eos
             RUN if ! getent passwd #{username}; then \
-                  adduser -g "kitchen user" -h #{homedir} -s /bin/ash -D #{username}; \
+                  adduser -g "kitchen user" -h #{homedir} -s /bin/ash #{username}; \
                   usermod -p * #{username}; \
                 fi
           eos

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -252,6 +252,14 @@ module Kitchen
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
           eos
+        when 'alpine'
+          <<-eos
+            RUN apk add --no-cache busybox openssh shadow sudo
+            RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
+            RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
+            RUN [ -f "/etc/ssh/ssh_host_ecdsa_key" ] || ssh-keygen -A -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key
+            RUN [ -f "/etc/ssh/ssh_host_ed25519_key" ] || ssh-keygen -A -t ed25519 -f /etc/ssh/ssh_host_ed25519_key
+          eos
         else
           raise ActionFailed,
           "Unknown platform '#{config[:platform]}'"

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -269,21 +269,21 @@ module Kitchen
         public_key = IO.read(config[:public_key]).strip
         homedir = username == 'root' ? '/root' : "/home/#{username}"
 
-        # case config[:platform]
+        case config[:platform]
         # alpine useradd throws warning, so use adduser instead
-        # when 'alpine'
-        #   user = <<-eos
-        #     RUN if ! getent passwd #{username}; then \
-        #           adduser -h #{homedir} -s /bin/bash -D #{username}; \
-        #         fi
-        #   eos
-        # else
-        user = <<-eos
-          RUN if ! getent passwd #{username}; then \
-                useradd -d #{homedir} -m -s /bin/bash -p '*' #{username}; \
-              fi
-        eos
-        # end
+        when 'alpine'
+          user = <<-eos
+            RUN if ! getent passwd #{username}; then \
+                  adduser -g "kitchen user" -h #{homedir} -s /bin/bash -D #{username}; \
+                fi
+          eos
+        else
+          user = <<-eos
+            RUN if ! getent passwd #{username}; then \
+                  useradd -d #{homedir} -m -s /bin/bash -p '*' #{username}; \
+                fi
+          eos
+        end
 
         base = <<-eos
           RUN echo "#{username} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
@@ -295,6 +295,7 @@ module Kitchen
           RUN chown #{username} #{homedir}/.ssh/authorized_keys
           RUN chmod 0600 #{homedir}/.ssh/authorized_keys
         eos
+
         custom = ''
         Array(config[:provision_command]).each do |cmd|
           custom << "RUN #{cmd}\n"


### PR DESCRIPTION
Note:

1. Chef does not work with alpine, but if using other provisioner, such as ansible, it shall work.

2. Also, by default busser is the verifier of kitchen, and kitchen installs chef, to use embedded ruby and gem to install busser. However with "require_chef_for_busser" kitchen-ansible settings, chef can be set to not to be installed. In this case if you still want to use busser, as long as the docker image has gem, it should work.

So this is ideal for test-kitchen + kitchen-docker with alpine + kitchen-ansible + busser + serverspec, no matter for local DEV, test driven infrastructure development, or CI.

For easier and faster usage, I created a Docker image based on ruby:alpine, and with busser/serverspec ansible preinstalled, see: [dockerhub](https://hub.docker.com/r/ironcore864/alpine-busser-serverspec/) and [git](https://github.com/IronCore864/alpine-busser-serverspec).
