### PR TITLE
Unprivileged execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,26 @@ devices:
   - /dev/vboxnetctl
 ```
 
+### username
+
+The username used to log in to the container. This parameter should only be
+changed if custom images are used.
+
+The default is `kitchen`
+
+### homedir
+
+The homedir of the login user.
+
+The default is `/home/#{username}`
+
+
+### unprivileged
+
+Don't allow the usage of `sudo` within the container. This is useful to test
+cookbooks that are designed to run without [root privileges](https://docs.chef.io/ctl_chef_client.html#run-as-non-root-user)
+
+
 ### build_context
 
 Transfer the cookbook directory (cwd) as build context. This is required for

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -201,6 +201,7 @@ module Kitchen
           env_variables << "ENV NO_PROXY #{config[:no_proxy]}\n"
         end
 
+	enforce_root = "USER 'root'"
         platform = case config[:platform]
         when 'debian', 'ubuntu'
           disable_upstart = <<-eos
@@ -284,7 +285,7 @@ module Kitchen
         end
         ssh_key = "RUN echo #{Shellwords.escape(public_key)} >> #{homedir}/.ssh/authorized_keys"
         # Empty string to ensure the file ends with a newline.
-        [from, env_variables, platform, base, custom, ssh_key, ''].join("\n")
+        [from, enforce_root, env_variables, platform, base, custom, ssh_key, ''].join("\n")
       end
 
       def dockerfile

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -45,6 +45,7 @@ module Kitchen
       default_config :run_command,   '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes ' +
                                      '-o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid'
       default_config :username,      'kitchen'
+      default_config :homedir,       nil
       default_config :tls,           false
       default_config :tls_verify,    false
       default_config :tls_cacert,    nil
@@ -259,7 +260,7 @@ module Kitchen
 
         username = config[:username]
         public_key = IO.read(config[:public_key]).strip
-        homedir = username == 'root' ? '/root' : "/home/#{username}"
+        homedir = config[:homedir] || ( username == 'root' ? '/root' : "/home/#{username}" )
 
         base = <<-eos
           RUN if ! getent passwd #{username}; then \


### PR DESCRIPTION
This changes allow the build a configuration for unprivileged chef execution.

Chef allows to be run as non-root user. This is useful in environments with strict privilege separations.

To test cookbooks in such a case, it must be possible to run
- the chef client without any privilege escalation
- on a predefined docker image, configured like production
- in a separate homedir

This patches introduce two new configuration parameters:
- `homedir` could be used to override the default homedir location
- `unprivileged` drops the default sudo rules for the unprivileged user

In addition the `root` user is enforced within the docker build, to make sure that all build steps for the image are working and the sshd could start without issues, even if the used docker image contains a `USER` directive.