### PR TITLE
Remove unnecessary input flag

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -308,13 +308,12 @@ module Kitchen
         cmd << " --no-cache" unless config[:use_cache]
         extra_build_options = config_to_options(config[:build_options])
         cmd << " #{extra_build_options}" unless extra_build_options.empty?
-        dockerfile_contents = dockerfile
         build_context = config[:build_context] ? '.' : '-'
         file = Tempfile.new('Dockerfile-kitchen', Dir.pwd)
         output = begin
           file.write(dockerfile)
           file.close
-          docker_command("#{cmd} -f #{Shellwords.escape(dockerfile_path(file))} #{build_context}", :input => dockerfile_contents)
+          docker_command("#{cmd} -f #{Shellwords.escape(dockerfile_path(file))} #{build_context}")
         ensure
           file.close unless file.closed?
           file.unlink


### PR DESCRIPTION
This PR removes the `:input` option (and the corresponding variable which holds the Dockerfile contents).

When a Docker image is being built via the `build_image` method, the `Dockerfile` is written to a temporary location and passed in as an argument (`-f`).

However, the string contents of the temporary `Dockerfile` are also passed in using the `:input` option.

On my system (OS X El Capitan, Docker for Mac 18.04.0-ce-mac62), this causes execution of `docker` (or rather, the **return** of `run_command`) to block because nothing has consumed stdin.

```
$ kitchen test --log-level=debug
-----> Starting Kitchen (v1.21.2)
D      [local command] BEGIN (docker >> /dev/null 2>&1)
D      [local command] END (0m0.11s)
-----> Cleaning up any prior instances of <bootstrap-ubuntu-1404>
-----> Destroying <bootstrap-ubuntu-1404>...
       Finished destroying <bootstrap-ubuntu-1404> (0m0.00s).
-----> Testing <bootstrap-ubuntu-1404>
-----> Creating <bootstrap-ubuntu-1404>...
D      [kitchen::driver::docker command] BEGIN (docker -H unix:///var/run/docker.sock build -f /Users/oogali/lab-salt-states/Dockerfile-kitchen20180517-45512-qnxq5o .)
...forever hung...^C^C^C
```

/cc @coderanger @cheeseplus @lamont-granquist  @robbkidd 