### PR TITLE
honour *_proxy environment variables

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -59,6 +59,10 @@ module Kitchen
 
       default_config :use_sudo, false
 
+      default_config :http_proxy,    ENV['http_proxy']
+      default_config :https_proxy,   ENV['https_proxy']
+      default_config :no_proxy,      ENV['no_proxy']
+
       default_config :image do |driver|
         driver.default_image
       end


### PR DESCRIPTION
Currently, proxy variables have to be configured in the .kitchen.yml or .kitchen.local.yml

This leads to coping the configuration around, maintain multiple files and make it error prone in complex environments.

This PR honors the *_proxy variables of they are set on the environment.