### PR TITLE
Override Docker Host/IP for SSH Connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ $MACHINE)"` then use the following:
 socket: tcp://192.168.59.103:2375
 ```
 
+### docker\_host
+
+Sets the hostname/IP used to connect to a container via SSH. Normally `localhost` (the default) is sufficient here,
+but when doing things like [mounted docker unix sockets into a container](https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/) in lieu of Docker-in-Docker, this can be useful.
 
 ### image
 

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -44,6 +44,8 @@ module Kitchen
       default_config :remove_images, false
       default_config :run_command,   '/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes ' +
                                      '-o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid'
+      # Used for SSH connections to containers
+      default_config :docker_host,   'localhost'
       default_config :username,      'kitchen'
       default_config :tls,           false
       default_config :tls_verify,    false
@@ -119,7 +121,7 @@ module Kitchen
         state[:ssh_key] = config[:private_key]
         state[:image_id] = build_image(state) unless state[:image_id]
         state[:container_id] = run_container(state) unless state[:container_id]
-        state[:hostname] = remote_socket? ? socket_uri.host : 'localhost'
+        state[:hostname] = remote_socket? ? socket_uri.host : config[:docker_host]
         state[:port] = container_ssh_port(state)
         if config[:wait_for_sshd]
           instance.transport.connection(state) do |conn|


### PR DESCRIPTION
Allow overriding the usage of `localhost` while still using a UNIX socket for Docker daemon connections.

This is useful when mounting `/var/run/docker.sock` into a container, and you need to connect to something like `172.17.0.1` instead of `localhost` to hit the port mappings (in lieu of Docker-in-Docker).