### PR TITLE
archlinux must be updated when repos are refreshed

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -230,7 +230,7 @@ module Kitchen
           <<-eos
             RUN pacman --noconfirm -Sy archlinux-keyring
             RUN pacman-db-upgrade
-            RUN pacman --noconfirm -Sy openssl openssh sudo curl
+            RUN pacman --noconfirm -Syu openssl openssh sudo curl
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
             RUN echo >/etc/security/limits.conf


### PR DESCRIPTION
Pacman does not resolve .so files, so if an so bump happens with one of these packages, it could break other packages.

`pacman: error while loading shared libraries: libpsl.so.5: cannot open shared object file: No such file or directory` is an example of the error right now.

https://gist.github.com/vodik/5660494