### PR TITLE
Remote docker need to override ssh address with containers because ci is picky like that

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,17 @@ Examples:
     net: br3
 ```
 
+### use\_container\_ip
+
+If you find that you need for the ssh connection that kitchen will make to be made to the built container's ip address ( some CI systems work like this ), set this to true.
+
+Examples:
+
+```yaml
+  use_conatiner_ip: true
+```
+
+
 ## Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -160,7 +160,6 @@ module Kitchen
         docker << " --tlscacert=#{config[:tls_cacert]}" if config[:tls_cacert]
         docker << " --tlscert=#{config[:tls_cert]}" if config[:tls_cert]
         docker << " --tlskey=#{config[:tls_key]}" if config[:tls_key]
-        puts "#{docker} #{cmd}"
         run_command("#{docker} #{cmd}", options.merge({
           quiet: !logger.debug?,
           use_sudo: config[:use_sudo],

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -121,6 +121,7 @@ module Kitchen
         state[:ssh_key] = config[:private_key]
         state[:image_id] = build_image(state) unless state[:image_id]
         state[:container_id] = run_container(state) unless state[:container_id]
+        state[:user_container_ip] = config[:use_container_ip]
         if state[:use_container_ip]
           state[:hostname] = container_ssh_ip_address(state)
         else

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -59,6 +59,8 @@ module Kitchen
 
       default_config :use_sudo, false
 
+      default_config :use_container_ip, false
+
       default_config :image do |driver|
         driver.default_image
       end
@@ -119,7 +121,11 @@ module Kitchen
         state[:ssh_key] = config[:private_key]
         state[:image_id] = build_image(state) unless state[:image_id]
         state[:container_id] = run_container(state) unless state[:container_id]
-        state[:hostname] = remote_socket? ? socket_uri.host : 'localhost'
+        if state[:use_container_ip]
+          state[:hostname] = container_ssh_ip_address(state)
+        else
+          state[:hostname] = remote_socket? ? socket_uri.host : 'localhost'
+        end
         state[:port] = container_ssh_port(state)
         if config[:wait_for_sshd]
           instance.transport.connection(state) do |conn|
@@ -381,6 +387,15 @@ module Kitchen
         rescue
           raise ActionFailed,
           'Docker reports container has no ssh port mapped'
+        end
+      end
+
+      def container_ssh_ip_address(state)
+        begin
+          docker_command("docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'  #{state[:container_id]}")
+        rescue
+          raise ActionFailed,
+          'Docker cannot report on the IpAddress'
         end
       end
 

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -126,7 +126,7 @@ module Kitchen
         else
           state[:hostname] = remote_socket? ? socket_uri.host : 'localhost'
         end
-        state[:port] = container_ssh_port(state)
+        state[:port] = state[:use_container_ip] ? 22 : container_ssh_port(state)
         if config[:wait_for_sshd]
           instance.transport.connection(state) do |conn|
             conn.wait_until_ready

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -160,6 +160,7 @@ module Kitchen
         docker << " --tlscacert=#{config[:tls_cacert]}" if config[:tls_cacert]
         docker << " --tlscert=#{config[:tls_cert]}" if config[:tls_cert]
         docker << " --tlskey=#{config[:tls_key]}" if config[:tls_key]
+        puts "#{docker} #{cmd}"
         run_command("#{docker} #{cmd}", options.merge({
           quiet: !logger.debug?,
           use_sudo: config[:use_sudo],
@@ -393,7 +394,7 @@ module Kitchen
 
       def container_ssh_ip_address(state)
         begin
-          docker_command("docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'  #{state[:container_id]}")
+          docker_command("inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'  #{state[:container_id]}")
         rescue
           raise ActionFailed,
           'Docker cannot report on the IpAddress'

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -121,7 +121,7 @@ module Kitchen
         state[:ssh_key] = config[:private_key]
         state[:image_id] = build_image(state) unless state[:image_id]
         state[:container_id] = run_container(state) unless state[:container_id]
-        state[:user_container_ip] = config[:use_container_ip]
+        state[:use_container_ip] = config[:use_container_ip]
         if state[:use_container_ip]
           state[:hostname] = container_ssh_ip_address(state)
         else


### PR DESCRIPTION
I don't know how you describe this.. @iennae suggested maybe "docker beside docker", which looks something like 👬.

ANYHOOZLE... 

In our CI System of choice, we can run docker, but we can't get the primary shell of the CI system to open any TCP ports from itself to the containers that it runs. Our CI system expects you to start up containers that are servers to be tested, and containers that are clients to those servers ( i.e. inside the same docker network ). It then wants you to run test from the clients to the servers ( vs from the sort of puppetmaster/coordinating primary shell ). 

This left us in the undesirable position of needing the support for remote docker which was already in kitchen-docker ( yay! ), but also needing to specify the IP address that SSH needed to connect to ( outside of it being the remote docker host or localhost ). 

Plus side: It was actually not that hard! This framework is pretty straightforward. 
Down side: Ruby isn't my primary language, so you may these expressions to not be idiomatic, and I didn't see how the test suite should be modified to confirm this behavior. 

I'm happy to answer any questions about this, and attempt to address whatever feedback you've got. 

I can't imagine we're the only people dealing with this, I've noticed that **a lot** of github repos using test kitchen are using travis ci with the flags set to still get the old style "full vm running dockerd" experience. I don't actually use travis, but their docs look like my CI system's docs.. YMMV, IANAL, etc. 

