### PR TITLE
require base64

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -21,6 +21,7 @@ require 'uri'
 require 'net/ssh'
 require 'tempfile'
 require 'shellwords'
+require 'base64'
 
 require 'kitchen/driver/base'
 


### PR DESCRIPTION
This fixes `uninitialized constant Kitchen::Driver::Docker::Base64`.