### PR TITLE
Feature: use_internal_docker_network

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,19 @@ Examples:
     net: br3
 ```
 
+### use_internal_docker_network
+
+If you want to use kitchen-docker from within another Docker container you'll
+need to set this to true. When set to true uses port 22 as the SSH port and
+the IP of the container that chef is going to run in as the hostname so that
+you can connect to it over SSH from within another Docker container.
+
+Examples:
+
+```yaml
+  use_internal_docker_network: true
+```
+
 ## Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -395,7 +395,7 @@ module Kitchen
 
       def container_ip(state)
         begin
-          cmd = "inspect --format '{{ .NetworkSettings.IPAddress }}'"
+          cmd = "inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'"
           cmd << " #{state[:container_id]}"
           docker_command(cmd).strip
         rescue


### PR DESCRIPTION
Yet another PR to add use_internal_docker_network feature based on @amalucelli's work in #304 as well as @AaronKalair's work in #283 

Modified the container_ip method to fetch the container's .IPAddress from .NetworkSettings.Networks using docker inspect as recommended by @rs017991 and https://docs.docker.com/engine/reference/commandline/inspect/#examples

This resolves #215 