### PR TITLE
Custom build path

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -306,7 +306,7 @@ module Kitchen
         extra_build_options = config_to_options(config[:build_options])
         cmd << " #{extra_build_options}" unless extra_build_options.empty?
         dockerfile_contents = dockerfile
-        build_context = config[:build_context] ? '.' : '-'
+        build_context = config[:build_context]
         file = Tempfile.new('Dockerfile-kitchen', Dir.pwd)
         output = begin
           file.write(dockerfile)

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -306,7 +306,7 @@ module Kitchen
         extra_build_options = config_to_options(config[:build_options])
         cmd << " #{extra_build_options}" unless extra_build_options.empty?
         dockerfile_contents = dockerfile
-        build_context = config[:build_context]
+        build_context = config[:build_context] ? '.' : '-'
         file = Tempfile.new('Dockerfile-kitchen', Dir.pwd)
         output = begin
           file.write(dockerfile)

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -56,6 +56,7 @@ module Kitchen
       default_config :public_key,    File.join(Dir.pwd, '.kitchen', 'docker_id_rsa.pub')
       default_config :build_options, nil
       default_config :run_options,   nil
+      default_config :build_path,    '.'
 
       default_config :use_sudo, false
 
@@ -306,7 +307,7 @@ module Kitchen
         extra_build_options = config_to_options(config[:build_options])
         cmd << " #{extra_build_options}" unless extra_build_options.empty?
         dockerfile_contents = dockerfile
-        build_context = config[:build_context] ? '.' : '-'
+        build_context = config[:build_context] ? config[:build_path] : '-'
         file = Tempfile.new('Dockerfile-kitchen', Dir.pwd)
         output = begin
           file.write(dockerfile)


### PR DESCRIPTION
In some cases, I want to collect a container from a specific folder.

For example, in my image folder:
```bash
Dockerfile entry.sh
```
And I only need these 2 files to compile the image. 

My commit allows you to execute the bash command:
```bash
docker build -f Dockerfile image
```

by adding in .kitchen.yml:
```yaml
build_path: 'image'
```