### PR TITLE
Add support for the opensuse/leap images

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,6 +23,7 @@ platforms:
 - name: opensuse-42.3
   driver:
     image: opensuse:42.3
+- name: opensuse/leap-42
 # - name: arch
 #   driver:
 #     image: base/archlinux

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ suite container for Test Kitchen. Kitchen Docker currently supports:
 * `debian` or `ubuntu`
 * `amazonlinux`, `rhel`, `centos`, `fedora` or `oraclelinux`
 * `gentoo` or `gentoo-paludis`
-* `opensuse/leap`, `opensuse` or `sles`
+* `opensuse/tumbleweed`, `opensuse/leap`, `opensuse` or `sles`
 
 The default will be computed, using the platform name (see the Default
 Configuration section for more details).

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ suite container for Test Kitchen. Kitchen Docker currently supports:
 * `debian` or `ubuntu`
 * `amazonlinux`, `rhel`, `centos`, `fedora` or `oraclelinux`
 * `gentoo` or `gentoo-paludis`
-* `opensuse` or `sles`
+* `opensuse/leap`, `opensuse` or `sles`
 
 The default will be computed, using the platform name (see the Default
 Configuration section for more details).

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -232,7 +232,7 @@ module Kitchen
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
             RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''
           eos
-        when 'opensuse', 'sles'
+        when 'opensuse/leap', 'opensuse', 'sles'
           <<-eos
             ENV container docker
             RUN zypper install -y sudo openssh which curl

--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -91,7 +91,7 @@ module Kitchen
         run_command("#{config[:binary]} >> #{dev_null} 2>&1", quiet: true, use_sudo: config[:use_sudo])
         rescue
           raise UserError,
-          'You must first install the Docker CLI tool http://www.docker.io/gettingstarted/'
+          'You must first install the Docker CLI tool https://www.docker.com/get-started'
       end
 
       def dev_null
@@ -232,7 +232,7 @@ module Kitchen
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
             RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''
           eos
-        when 'opensuse/leap', 'opensuse', 'sles'
+        when 'opensuse/tumbleweed', 'opensuse/leap', 'opensuse', 'sles'
           <<-eos
             ENV container docker
             RUN zypper install -y sudo openssh which curl


### PR DESCRIPTION
The previous opensuse images are deprecated on dockerhub.

Signed-off-by: Tim Smith <tsmith@chef.io>