### PR TITLE
fix: docker over user defined networks

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -395,7 +395,7 @@ module Kitchen
 
       def container_ip(state)
         begin
-          cmd = "inspect --format '{{ .NetworkSettings.IPAddress }}'"
+          cmd = "inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'"
           cmd << " #{state[:container_id]}"
           docker_command(cmd).strip
         rescue


### PR DESCRIPTION
I started having the same issue as https://github.com/test-kitchen/kitchen-docker/pull/304#discussion_r218944342

> there is an issue when using this setup with user defined networks.
> 
> In those cases, the IPAddress at the NetworkSettings level is empty, and instead needs to be found on the Network. That nested value is also there when using the default bridge network, so I would think that it should be safe to use in any case:
> I was able to get this working by changing the template to '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'

This happens over [Google Cloud Build](url) platform, where a new docker container is created to run the tests using a [custom named network (`cloudbuild`)](https://cloud.google.com/cloud-build/docs/overview), making it impossible to reach the original container without this change.