### PR TITLE
suse platform: use system script for ssh key initialization

### DIFF
--- a/lib/kitchen/docker/container/linux.rb
+++ b/lib/kitchen/docker/container/linux.rb
@@ -140,8 +140,7 @@ module Kitchen
                        <<-CODE
                          ENV container docker
                          RUN zypper install -y sudo openssh which curl
-                         RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
-                         RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''
+                         RUN /usr/sbin/sshd-gen-keys-start
                        CODE
                      when 'arch'
                        # See https://bugs.archlinux.org/task/47052 for why we


### PR DESCRIPTION
The openssh in the latest suse image (opensuse/leap:15) needs all types of ssh keys

Signed-off-by: Michael Geiger <info@mgeiger.de>