### PR TITLE
Allow Multiple Platform Names for Windows

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -29,7 +29,7 @@ platforms:
 - name: debian-9
 - name: opensuse-42.3
   driver:
-    image: opensuse:42.3
+    image: opensuse/leap:42.3
 - name: opensuse/leap-42
 # - name: arch
 #   driver:

--- a/lib/kitchen/docker/helpers/container_helper.rb
+++ b/lib/kitchen/docker/helpers/container_helper.rb
@@ -72,7 +72,7 @@ module Kitchen
           path = replace_env_variables(state, path)
           cmd = "mkdir -p #{path}"
 
-          if state[:platform] == 'windows'
+          if state[:platform].include?('windows')
             psh = "-Command if(-not (Test-Path \'#{path}\')) { New-Item -Path \'#{path}\' -Force }"
             cmd = build_powershell_command(psh)
           end
@@ -99,7 +99,7 @@ module Kitchen
           # Retrieves all environment variables from inside container
           vars = {}
 
-          if state[:platform] == 'windows'
+          if state[:platform].include?('windows')
             cmd = build_powershell_command('-Command [System.Environment]::GetEnvironmentVariables() ^| ConvertTo-Json')
             cmd = build_exec_command(state, cmd)
             stdout = docker_command(cmd, suppress_output: !logger.debug?).strip

--- a/lib/kitchen/transport/docker.rb
+++ b/lib/kitchen/transport/docker.rb
@@ -98,7 +98,7 @@ module Kitchen
         end
 
         def container
-          @container ||= if @options[:platform] == 'windows'
+          @container ||= if @options[:platform].include?('windows')
                            Kitchen::Docker::Container::Windows.new(@options)
                          else
                            Kitchen::Docker::Container::Linux.new(@options)


### PR DESCRIPTION
Currently, only one platform name can be used for Windows as the platform name has to be exactly named "windows" as shown in the kitchen config below:

```
platforms:
  - name: windows
    driver_config:
      image: mcr.microsoft.com/windows/servercore:1607
      platform: windows
```

This update checks to see if the platform name includes the string "windows" instead (shown in the configuration below):

```
platforms:
  - name: windows-chef-12
    provisioner:
      product_name: chef
      product_version: 12.14.89
    driver_config:
      image: mcr.microsoft.com/windows/servercore:1607
      platform: windows
  - name: windows-chef-14
    provisioner:
      product_name: chef
      product_version: 14.7.17
    driver_config:
      image: mcr.microsoft.com/windows/servercore:1607
      platform: windows
  - name: windows-chef-latest
    provisioner:
      product_name: chef
    driver_config:
      image: mcr.microsoft.com/windows/servercore:1607
      platform: windows
```

Also updated test kitchen config with correct opensuse image name for the CI test to pass.