### PR TITLE
Support GPU in docker

### DIFF
--- a/lib/kitchen/docker/helpers/cli_helper.rb
+++ b/lib/kitchen/docker/helpers/cli_helper.rb
@@ -54,6 +54,7 @@ module Kitchen
           cmd << " -h #{config[:hostname]}" if config[:hostname]
           cmd << " -m #{config[:memory]}" if config[:memory]
           cmd << " -c #{config[:cpu]}" if config[:cpu]
+          cmd << " --gpus #{config[:gpus]}" if config[:gpus]
           cmd << " -e http_proxy=#{config[:http_proxy]}" if config[:http_proxy]
           cmd << " -e https_proxy=#{config[:https_proxy]}" if config[:https_proxy]
           cmd << ' --privileged' if config[:privileged]


### PR DESCRIPTION
Since 19.03, NVIDIA GPUs are now natively supported as devices in the Docker runtime. See https://docs.docker.com/config/containers/resource_constraints/#gpu and https://github.com/NVIDIA/nvidia-docker

For example:
```bash
docker run --gpus all nvidia/cuda:9.0-base nvidia-smi
```
The only change I made in this PR was adding
```ruby
cmd << " --gpus #{config[:gpus]}" if config[:gpus]
```
in `cli_helper.rb`. I tested it locally and it worked. But i'm not sure how to test this without a GPU VM though.

Thanks