### PR TITLE
update gem dependencies introduced in #340

### DIFF
--- a/kitchen-docker.gemspec
+++ b/kitchen-docker.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'test-kitchen', '>= 1.0.0'
+  spec.add_dependency 'kitchen-inspec', '~> 1.1'
+  spec.add_dependency 'kitchen-docker', '~> 1.34.2'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
@@ -35,6 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'codecov', '~> 0.0', '>= 0.0.2'
 
   # Integration testing gems.
-  spec.add_development_dependency 'kitchen-inspec', '~> 1.1'
   spec.add_development_dependency 'train', '~> 2.1'
 end


### PR DESCRIPTION
The great :tada: work in #340 introduced a few new gem dependencies.
I would vote for addin these not `development_dependency`, but as `dependency` because using the new `docker transport` without these gems will just not work.