### PR TITLE
WIP: take last match instead of first match when parsing image-id

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,9 +27,9 @@ platforms:
 - name: oraclelinux-7
 - name: debian-8
 - name: debian-9
-- name: opensuse-42.3
-  driver:
-    image: opensuse/leap:42.3
+#- name: opensuse-42.3
+#  driver:
+#    image: opensuse/leap:42.3
 - name: opensuse/leap-42
 # - name: arch
 #   driver:

--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -25,12 +25,17 @@ module Kitchen
         include Kitchen::Docker::Helpers::ContainerHelper
 
         def parse_image_id(output)
+          image_id = nil
           output.each_line do |line|
             if line =~ /image id|build successful|successfully built/i
-              return line.split(/\s+/).last
+              image_id = line.split(/\s+/).last
             end
           end
-          raise ActionFailed, 'Could not parse Docker build output for image ID'
+          if image_id.nil?
+            raise ActionFailed, 'Could not parse Docker build output for image ID'
+          else
+            return image_id
+          end
         end
 
         def remove_image(state)


### PR DESCRIPTION
(supersedes #332)
We have some test suites running with kitchen-docker that do `pip install` as part of their provisioning.

This sometimes triggers a bug in the parsing code of kitchen-docker which detects the image IDs of the temporary docker images that get built during setup.

Some abbreviated output showing what happens:

- one of the provision commands runs `pip install ansible-modules-hashivault`

- pip install generates a lot of output which includes:
   ```
       Successfully built ansible-modules-hashivault ansible PyYAML pycparser
   ```
   and then:
   ```
   Removing intermediate container 16f5a8da423d
           ---> 21719b47cd09
           Successfully built 21719b47cd09
   ```

   At this point, kitchen-ansible should have detected that the intermediate image is `21719b47cd09` but the code in `lib/kitchen/driver/docker.rb` takes the **first** match for "Successfully built" which is the output from pip, so the intermediate image ID gets erroneously detected as `pycparser`

- the next stage then tries to run a docker image called "pycparser" instead of the intermediate docker image just built, and fails:
   ```
   D      [kitchen::driver::docker command] BEGIN (docker -H unix:///var/run/docker.sock run -d -p 22 --name ldapaccessubuntu1604-nologin-05106a855c5a-4y8usc0n pycparser /usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid)
          Unable to find image 'pycparser:latest' locally
          docker: Error response from daemon: pull access denied for pycparser, repository does not exist or may require 'docker login'.
          See 'docker run --help'.
   ```

My PR changes `parse_image_id` so it detects the last match in the output instead of the first match.

This fixes issue #241

Thanks,
Andy