### PR TITLE
Fix Docker image deletion when using remove_images: true

### DIFF
--- a/lib/kitchen/docker/container/linux.rb
+++ b/lib/kitchen/docker/container/linux.rb
@@ -29,16 +29,14 @@ module Kitchen
         end
 
         def create(state)
-          super
-
           debug('Creating Linux container')
           generate_keys
 
           state[:ssh_key] = @config[:private_key]
           state[:image_id] = build_image(state, dockerfile) unless state[:image_id]
           state[:container_id] = run_container(state, 22) unless state[:container_id]
-          state[:hostname] = 'localhost'
           state[:port] = container_ssh_port(state)
+          super
         end
 
         def execute(command)

--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -35,7 +35,7 @@ module Kitchen
 
         def remove_image(state)
           image_id = state[:image_id]
-          docker_command("rmi #{image_id}")
+          run_command("docker ps -a | grep -q #{image_id} && echo 'Can not delete such image; It is being used by running container/s' || docker rmi #{image_id}")
         end
 
         def build_image(state, dockerfile)


### PR DESCRIPTION
Hi all!

This PR resolves #360

My fix is based on the idea of deleting the target Docker image only if it's not being used by an existing container, in other cases Kitchen will print an INFO message. 

**`Note`**: I first merged the fix of https://github.com/test-kitchen/kitchen-docker/pull/356 from the corresponding fork branch: [paulcalabro:fix-ip-address-issue](https://github.com/paulcalabro/kitchen-docker/tree/fix-ip-address-issue).

Kr,

Rshad