### PR TITLE
Retrieve hostname state data after container is launched

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 A Test Kitchen Driver and Transport for Docker.
 
+***MAINTAINERS WANTED***: This Test-Kitchen driver is currently without a maintainer and has many known issues. If you're interested in maintaining this driver for the long run including expanding the CI testing please reach out on [Chef Community Slack: #test-kitchen](https://chefcommunity.slack.com/archives/C2B6G1WCQ). Until such a time that this driver is maintained we highly recommend the [kitchen-dokken](https://github.com/test-kitchen/kitchen-dokken) for Chef Infra testing with Docker containers.
+
 ## Requirements
 
 * [Docker][docker_installation] **(>= 1.5)**

--- a/lib/kitchen/docker/container.rb
+++ b/lib/kitchen/docker/container.rb
@@ -37,13 +37,27 @@ module Kitchen
         end
 
         state[:username] = @config[:username]
-        state[:hostname] = 'localhost'
+      end
+
+      def destroy(state)
+        info("[Docker] Destroying Docker container #{state[:container_id]}") if state[:container_id]
+        remove_container(state) if container_exists?(state)
+
+        if @config[:remove_images] && state[:image_id]
+          remove_image(state) if image_exists?(state)
+        end
+      end
+
+      def hostname(state)
+        hostname = 'localhost'
 
         if remote_socket?
-          state[:hostname] = socket_uri.host
-        elsif config[:use_internal_docker_network]
-          state[:hostname] = container_ip_address(state)
+          hostname = socket_uri.host
+        elsif @config[:use_internal_docker_network]
+          hostname = container_ip_address(state)
         end
+
+        hostname
       end
 
       def upload(locals, remote)
@@ -55,15 +69,6 @@ module Kitchen
         end
 
         files
-      end
-
-      def destroy(state)
-        info("[Docker] Destroying Docker container #{state[:container_id]}") if state[:container_id]
-        remove_container(state) if container_exists?(state)
-
-        if @config[:remove_images] && state[:image_id]
-          remove_image(state) if image_exists?(state)
-        end
       end
     end
   end

--- a/lib/kitchen/docker/container/linux.rb
+++ b/lib/kitchen/docker/container/linux.rb
@@ -37,7 +37,7 @@ module Kitchen
           state[:ssh_key] = @config[:private_key]
           state[:image_id] = build_image(state, dockerfile) unless state[:image_id]
           state[:container_id] = run_container(state, 22) unless state[:container_id]
-          state[:hostname] = 'localhost'
+          state[:hostname] = hostname(state)
           state[:port] = container_ssh_port(state)
         end
 

--- a/lib/kitchen/docker/container/windows.rb
+++ b/lib/kitchen/docker/container/windows.rb
@@ -30,6 +30,7 @@ module Kitchen
           state[:username] = @config[:username]
           state[:image_id] = build_image(state, dockerfile) unless state[:image_id]
           state[:container_id] = run_container(state) unless state[:container_id]
+          state[:hostname] = hostname(state)
         end
 
         def execute(command)


### PR DESCRIPTION
Signed-off-by: Jeffrey Coe <jeffrey.coe@cerner.com>

# Description

Retrieves hostname state data after the container is launched. This fixes an issue where the container ID was not set when it attempted to retrieve the container IP address if the use_internal_docker_network option was set.

## Issues Resolved

Fixes issue #366 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
