### PR TITLE
Use less verbose and quicker setup on Gentoo

### DIFF
--- a/lib/kitchen/docker/helpers/dockerfile_helper.rb
+++ b/lib/kitchen/docker/helpers/dockerfile_helper.rb
@@ -80,8 +80,8 @@ module Kitchen
 
         def gentoo_platform
           <<-CODE
-            RUN emerge --sync
-            RUN emerge net-misc/openssh app-admin/sudo
+            RUN emerge-webrsync
+            RUN emerge --quiet --noreplace net-misc/openssh app-admin/sudo
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -A -t rsa -f /etc/ssh/ssh_host_rsa_key
             RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -A -t dsa -f /etc/ssh/ssh_host_dsa_key
           CODE


### PR DESCRIPTION
# Description

Creating a docker image on Gentoo uses verbose and slow approach to syncing the repository and installing openssh & sudo. This becomes an issue when provisioning Gentoo containers. This pull request:
- replaces the current `emerge --sync` with `emerge-webrsync`, which runs much quicker (21s compared to 2m18s on a test machine);
- emerges openssh and sudo with `--quiet` to decrease verbosity and  `--noreplace` to avoid reinstalling a package that is already installed.

## Issues Resolved

None.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
