### PR TITLE
Run the apt-get update in-line with the package install

### DIFF
--- a/lib/kitchen/docker/helpers/dockerfile_helper.rb
+++ b/lib/kitchen/docker/helpers/dockerfile_helper.rb
@@ -62,8 +62,7 @@ module Kitchen
           packages = <<-CODE
             ENV DEBIAN_FRONTEND noninteractive
             ENV container docker
-            RUN apt-get update
-            RUN apt-get install -y sudo openssh-server curl lsb-release
+            RUN apt-get update && apt-get install -y sudo openssh-server curl lsb-release
           CODE
           config[:disable_upstart] ? disable_upstart + packages : packages
         end


### PR DESCRIPTION
# Description

Without this, if your system has a copy of the cached apt repos that is invalid, the apt-get install will fail.

## Issues Resolved

None that I see

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
