### PR TITLE
lowercase the instance-name

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -76,7 +76,7 @@ module Kitchen
           (Etc.getlogin || 'nologin').gsub(/\W/, ''),
           Socket.gethostname.gsub(/\W/, '')[0..20],
           Array.new(8) { rand(36).to_s(36) }.join
-        ].join('-')
+        ].join('-').downcase
       end
 
       default_config :platform do |driver|


### PR DESCRIPTION
# Description

Lowercase the instance-name to avoid issues since docker does not allow instance with capital cases

## Issues Resolved

### stacktrace

```
       docker: invalid reference format: repository name must be lowercase.
       See 'docker run --help'.
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #create action: [Expected process to exit with [0], but received '125'
---- Begin output of docker -H unix:///var/run/docker.sock run -d -p 22 --name standardubuntu2004-vmartinez-VictorsMacBookProloca-gzc7n64i --privileged PyYAML /usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid ----
STDOUT: 
STDERR: docker: invalid reference format: repository name must be lowercase.
See 'docker run --help'.
---- End output of docker -H unix:///var/run/docker.sock run -d -p 22 --name standardubuntu2004-vmartinez-VictorsMacBookProloca-gzc7n64i --privileged PyYAML /usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid ----
Ran docker -H unix:///var/run/docker.sock run -d -p 22 --name standardubuntu2004-vmartinez-VictorsMacBookProloca-gzc7n64i --privileged PyYAML /usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid returned 125] on standard-ubuntu-2004
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
```

### Environment

```bash
$ gem list --local | grep "kitchen"
kitchen-ansible (0.50.0)
kitchen-docker (2.9.0)
test-kitchen (2.7.2, 2.2.5)
$ ruby --version       
ruby 2.6.3p62 (2019-04-16 revision 67580) [universal.x86_64-darwin19]
$ gem --version                    
3.0.3
$ docker --version                   
Docker version 19.03.13, build 4484c46d9d
$ uname -a  
Darwin Victors-MacBook-Pro.local 19.6.0 Darwin Kernel Version 19.6.0: Mon Aug 31 22:12:52 PDT 2020; root:xnu-6153.141.2~1/RELEASE_X86_64 x86_64
```
## Check List

~~- [ ] All tests pass. See TESTING.md for details.~~ I cannot find any references
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
