### PR TITLE
Fixes issues where remove_images fails if the image is in use

### DIFF
--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -35,7 +35,12 @@ module Kitchen
 
         def remove_image(state)
           image_id = state[:image_id]
-          docker_command("rmi #{image_id}")
+          if image_in_use?(state)
+            info("[Docker] Image ID #{image_id} is in use. Skipping removal")
+          else
+            info("[Docker] Removing image with Image ID #{image_id}.")
+            docker_command("rmi #{image_id}")
+          end
         end
 
         def build_image(state, dockerfile)
@@ -61,6 +66,10 @@ module Kitchen
 
         def image_exists?(state)
           state[:image_id] && !!docker_command("inspect --type=image #{state[:image_id]}") rescue false
+        end
+
+        def image_in_use?(state)
+          docker_command('ps -a', suppress_output: !logger.debug?).include?(state[:image_id])
         end
       end
     end


### PR DESCRIPTION
# Description
Previously, when `remove_images` was set to true, you would receive an error if the image was in use somewhere else. This fixes it by checking to see if the image is in use and skipping image removal if that is the case. It takes the idea presented in #361 and incorporates the feedback on that PR.

## Issues Resolved

This PR fixes #360 

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
