### PR TITLE
disables docker buildkit (fixes #337)

### DIFF
--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -50,7 +50,8 @@ module Kitchen
                      file.write(dockerfile)
                      file.close
                      docker_command("#{cmd} -f #{Shellwords.escape(dockerfile_path(file))} #{build_context}",
-                                    input: dockerfile_contents)
+                                    input: dockerfile_contents,
+                                    environment: { DOCKER_BUILDKIT: '0' })
                    ensure
                      file.close unless file.closed?
                      file.unlink


### PR DESCRIPTION
# Description

Disables docker buildkit (enabled by default on new installs) so that kitchen can get the `docker build` output and parse the image id.

## Issues Resolved

#337