### PR TITLE
add support for build_option -q #225

### DIFF
--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -26,7 +26,7 @@ module Kitchen
 
         def parse_image_id(output)
           output.each_line do |line|
-            if line =~ /image id|build successful|successfully built/i
+            if line =~ /image id|build successful|successfully built|sha256:/i
               return line.split(/\s+/).last
             end
           end


### PR DESCRIPTION
# Description

Adds support for the build_option: -q which outputs a sha256 image ID.

## Issues Resolved

"Could not parse Docker build output for image ID" in docker version 1.12.1 using build_options `-q` #225

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
