### PR TITLE
Updates image_helper for additional output line matching

### DIFF
--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -26,8 +26,9 @@ module Kitchen
 
         def parse_image_id(output)
           output.each_line do |line|
-            if line =~ /image id|build successful|successfully built/i
-              return line.split(/\s+/).last
+            if line =~ /image id|build successful|successfully built|writing image/i
+              img_id = line.split(/\s+/).last
+              return img_id
             end
           end
           raise ActionFailed, 'Could not parse Docker build output for image ID'


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

# Description

Fixes the error `Could not parse Docker build output for image ID` which was previously mentioned in #337   and #378 
This error is still currently present using the default options with Test Kitchen and `Docker version 20.10.5, build 55c4c88`

## Issues Resolved

Mentions of `Could not parse Docker build output for image ID` located in:
- #337 
- #378 

## Check List

- [X] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
