### PR TITLE
README.md: Fix link to getting-started page

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ limitations under the License.
 [docker_upstart_issue]:   https://github.com/dotcloud/docker/issues/223
 [docker_index]:           https://index.docker.io/
 [docker_default_image]:   https://index.docker.io/_/base/
-[test_kitchen_docs]:      http://kitchen.ci/docs/getting-started/
+[test_kitchen_docs]:      https://kitchen.ci/docs/getting-started/introduction/
 [chef_omnibus_dl]:        https://downloads.chef.io/chef-client/
 [cpu_shares]:             https://docs.fedoraproject.org/en-US/Fedora/17/html/Resource_Management_Guide/sec-cpu.html
 [memory_limit]:           https://docs.fedoraproject.org/en-US/Fedora/17/html/Resource_Management_Guide/sec-memory.html


### PR DESCRIPTION
Line 18 `Please read the Test Kitchen [docs][test_kitchen_docs]...` points to http://kitchen.ci/docs/getting-started/ which doesn't exist.  This changes the link to https://kitchen.ci/docs/getting-started/introduction/

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
