### PR TITLE
feat(dockerfile_helper): add support for `almalinux` & `rockylinux`

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ suite container for Test Kitchen. Kitchen Docker currently supports:
 
 * `arch`
 * `debian` or `ubuntu`
-* `amazonlinux`, `rhel`, `centos`, `fedora` or `oraclelinux`
+* `amazonlinux`, `rhel`, `centos`, `fedora`, `oraclelinux`, `almalinux` or `rockylinux`
 * `gentoo` or `gentoo-paludis`
 * `opensuse/tumbleweed`, `opensuse/leap`, `opensuse` or `sles`
 * `windows`

--- a/lib/kitchen/docker/helpers/dockerfile_helper.rb
+++ b/lib/kitchen/docker/helpers/dockerfile_helper.rb
@@ -34,7 +34,7 @@ module Kitchen
             gentoo_paludis_platform
           when 'opensuse/tumbleweed', 'opensuse/leap', 'opensuse', 'sles'
             opensuse_platform
-          when 'rhel', 'centos', 'oraclelinux', 'amazonlinux'
+          when 'rhel', 'centos', 'oraclelinux', 'amazonlinux', 'almalinux', 'rockylinux'
             rhel_platform
           else
             raise ActionFailed, "Unknown platform '#{config[:platform]}'"


### PR DESCRIPTION
# Description

Our org (https://github.com/saltstack-formulas) use `kitchen-docker`
across ~100 repos.  We've already tested this patch successfully with
both:

* https://hub.docker.com/_/almalinux
* https://hub.docker.com/r/rockylinux/rockylinux

## Issues Resolved

N/a.

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.