### PR TITLE
Use Docker BuildKit, support multiple CPU architectures

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,7 +19,7 @@ platforms:
 - name: fedora-latest
   driver:
     provision_command:
-    - yum install libxcrypt-compat.x86_64 -y
+    - yum install libxcrypt-compat -y
     - curl -L https://www.chef.io/chef/install.sh | bash
 - name: centos-7
 - name: centos-8

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,11 +26,10 @@ platforms:
 - name: oraclelinux-7
 - name: rockylinux-8
 - name: debian-9
-# Removing opensuse CI tests temporarily due to an issue with the Chef install script not providing
-# the correct platform name for opensuse resulting in consistent failures for this platform
-#- name: opensuse-42.3
-#  driver:
-#    image: opensuse/leap:42.3
+- name: debian-10
+- name: opensuse-15
+  driver:
+    image: opensuse/leap:15
 - name: dockerfile
   driver:
     username: dockerfile
@@ -46,7 +45,7 @@ suites:
   driver:
     build_context: false
 - name: capabilities
-  includes: [debian-8,debian-9,ubuntu-16.04,ubuntu-18.04]
+  includes: [debian-9,debian-10,ubuntu-18.04,ubuntu-20.04]
   driver:
     provision_command:
     - curl -L https://www.chef.io/chef/install.sh | bash

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,10 +31,6 @@ platforms:
 #- name: opensuse-42.3
 #  driver:
 #    image: opensuse/leap:42.3
-- name: unknown
-  driver:
-    image: ubuntu:16.04
-    platform: ubuntu
 - name: dockerfile
   driver:
     username: dockerfile

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -58,6 +58,13 @@ suites:
     - apt-get install -y net-tools
     cap_drop:
     - NET_ADMIN
+- name: arm64
+  excludes: [debian-9]
+  driver:
+    docker_platform: linux/arm64
+- name: amd64
+  driver:
+    docker_platform: linux/amd64
 - name: inspec
   driver:
     provision_command: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,20 +14,19 @@ provisioner:
 
 platforms:
 - name: amazonlinux-2
-- name: ubuntu-16.04
 - name: ubuntu-18.04
+- name: ubuntu-20.04
 - name: fedora-latest
   driver:
     provision_command:
     - yum install libxcrypt-compat.x86_64 -y
     - curl -L https://www.chef.io/chef/install.sh | bash
-- name: centos-6
 - name: centos-7
-- name: oraclelinux-6
+- name: centos-8
 - name: oraclelinux-7
-- name: debian-8
+- name: rockylinux-8
 - name: debian-9
-# Removing opensuse CI tests temporarily due to an issue with the Chef install script not providing 
+# Removing opensuse CI tests temporarily due to an issue with the Chef install script not providing
 # the correct platform name for opensuse resulting in consistent failures for this platform
 #- name: opensuse-42.3
 #  driver:

--- a/README.md
+++ b/README.md
@@ -596,6 +596,20 @@ Examples:
   use_internal_docker_network: true
 ```
 
+### docker_platform
+
+Configure the CPU platform (architecture) used by docker to build the image.
+
+Examples:
+
+```yaml
+  docker_platform: linux/arm64
+```
+
+```yaml
+  docker_platform: linux/amd64
+```
+
 ## Development
 
 * Source hosted at [GitHub][repo]

--- a/lib/kitchen/docker/helpers/cli_helper.rb
+++ b/lib/kitchen/docker/helpers/cli_helper.rb
@@ -84,6 +84,7 @@ module Kitchen
           Array(config[:cap_add]).each { |cap| cmd << " --cap-add=#{cap}"} if config[:cap_add]
           Array(config[:cap_drop]).each { |cap| cmd << " --cap-drop=#{cap}"} if config[:cap_drop]
           Array(config[:security_opt]).each { |opt| cmd << " --security-opt=#{opt}"} if config[:security_opt]
+          cmd << " --platform=#{config[:docker_platform]}" if config[:docker_platform]
           extra_run_options = config_to_options(config[:run_options])
           cmd << " #{extra_run_options}" unless extra_run_options.empty?
           cmd << " #{image_id} #{config[:run_command]}"

--- a/lib/kitchen/docker/helpers/cli_helper.rb
+++ b/lib/kitchen/docker/helpers/cli_helper.rb
@@ -36,6 +36,26 @@ module Kitchen
           run_command("#{docker} #{cmd}", docker_shell_opts(options))
         end
 
+        # Copied from kitchen because we need stderr
+        def run_command(cmd, options = {})
+          if options.fetch(:use_sudo, false)
+            cmd = "#{options.fetch(:sudo_command, "sudo -E")} #{cmd}"
+          end
+          subject = "[#{options.fetch(:log_subject, "local")} command]"
+
+          debug("#{subject} BEGIN (#{cmd})")
+          sh = Mixlib::ShellOut.new(cmd, shell_opts(options))
+          sh.run_command
+          debug("#{subject} END #{Util.duration(sh.execution_time)}")
+          sh.error!
+          sh.stdout + sh.stderr
+        rescue Mixlib::ShellOut::ShellCommandFailed => ex
+          raise ShellCommandFailed, ex.message
+        rescue Exception => error # rubocop:disable Lint/RescueException
+          error.extend(Kitchen::Error)
+          raise
+        end
+
         def build_run_command(image_id, transport_port = nil)
           cmd = 'run -d'
           cmd << ' -i' if config[:interactive]

--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -46,6 +46,7 @@ module Kitchen
         def build_image(state, dockerfile)
           cmd = 'build'
           cmd << ' --no-cache' unless config[:use_cache]
+          cmd << " --platform=#{config[:docker_platform]}" if config[:docker_platform]
           extra_build_options = config_to_options(config[:build_options])
           cmd << " #{extra_build_options}" unless extra_build_options.empty?
           dockerfile_contents = dockerfile

--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -26,7 +26,11 @@ module Kitchen
 
         def parse_image_id(output)
           output.each_line do |line|
-            if line =~ /image id|build successful|successfully built|writing image/i
+            if line =~ /writing image sha256:[[:xdigit:]]{64} done/i
+              img_id = line[/writing image (sha256:[[:xdigit:]]{64}) done/i,1]
+              return img_id
+            end
+            if line =~ /image id|build successful|successfully built/i
               img_id = line.split(/\s+/).last
               return img_id
             end
@@ -52,7 +56,7 @@ module Kitchen
                      file.close
                      docker_command("#{cmd} -f #{Shellwords.escape(dockerfile_path(file))} #{build_context}",
                                     input: dockerfile_contents,
-                                    environment: { DOCKER_BUILDKIT: '0' })
+                                    environment: { BUILDKIT_PROGRESS: 'plain' })
                    ensure
                      file.close unless file.closed?
                      file.unlink

--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -50,12 +50,13 @@ module Kitchen
           extra_build_options = config_to_options(config[:build_options])
           cmd << " #{extra_build_options}" unless extra_build_options.empty?
           dockerfile_contents = dockerfile
-          build_context = config[:build_context] ? '.' : '-'
           file = Tempfile.new('Dockerfile-kitchen', Dir.pwd)
+          cmd << " -f #{Shellwords.escape(dockerfile_path(file))}" if config[:build_context]
+          build_context = config[:build_context] ? '.' : '-'
           output = begin
                      file.write(dockerfile)
                      file.close
-                     docker_command("#{cmd} -f #{Shellwords.escape(dockerfile_path(file))} #{build_context}",
+                     docker_command("#{cmd} #{build_context}",
                                     input: dockerfile_contents,
                                     environment: { BUILDKIT_PROGRESS: 'plain' })
                    ensure

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6
+FROM centos:7
 RUN yum clean all
 RUN yum install -y sudo openssh-server openssh-clients which curl htop
 RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key


### PR DESCRIPTION
# Description

This PR introduces support for Docker Buildkit and makes it the default way to build containers when executed with a supported version of Docker. Compatibility with the old build system is maintained.

Also introduces the ability to target a specific CPU architecture with docker, allowing builds of cross-platform containers where supported using the `--platform` switch in Docker.

All test suites have been updated to supported OS versions. Cross-platform build tests are also present.

## Issues Resolved

Proper solution for #337 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
