### PR TITLE
Update test suites

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,7 +22,6 @@ platforms:
     - yum install libxcrypt-compat -y
     - curl -L https://www.chef.io/chef/install.sh | bash
 - name: centos-7
-- name: centos-8
 - name: oraclelinux-7
 - name: rockylinux-8
 - name: debian-9
@@ -39,13 +38,13 @@ platforms:
 
 suites:
 - name: default
-  excludes: [arch]
+  excludes: [arch, debian-9]
 - name: context
-  excludes: [arch]
+  excludes: [arch, debian-9]
   driver:
     build_context: false
 - name: capabilities
-  includes: [debian-9,debian-10,ubuntu-18.04,ubuntu-20.04]
+  includes: [debian-10,ubuntu-18.04,ubuntu-20.04]
   driver:
     provision_command:
     - curl -L https://www.chef.io/chef/install.sh | bash


### PR DESCRIPTION
- Removed centos-8 due to EOL
- Made debian-9 platform-specific because chef does not support arm64 on 
this OS

Signed-off-by: Andrew Bobulsky <rulerof@gmail.com>

# Description

Makes all the tests pass on my M1 machine.

## Issues Resolved

None

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
