### PR TITLE
Release 2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Kitchen-Docker Changelog
 
+## 2.13.0 - June 10, 2022
+
+- Added CentOSStream and PhotonOS - [@garethgreenaway](https://github.com/garethgreenaway)
+- Fixed image parser when output includes a duration timestamp - [@RulerOf](https://github.com/RulerOf)
+- Updated the test suites - [@RulerOf](https://github.com/RulerOf)
+
 ## 2.12.0 - December 22, 2021
 
 - Support Docker BuildKit - [@RulerOf](https://github.com/RulerOf)

--- a/lib/kitchen/docker/docker_version.rb
+++ b/lib/kitchen/docker/docker_version.rb
@@ -16,6 +16,6 @@
 module Kitchen
   module Docker
     # Version string for Docker Kitchen driver
-    DOCKER_VERSION = "2.12.0"
+    DOCKER_VERSION = "2.13.0"
   end
 end


### PR DESCRIPTION
Signed-off-by: Ashique P S <Ashique.saidalavi@progress.com>

# Description

Release 2.13.0

The changes include:

- Added CentOSStream and PhotonOS - [@garethgreenaway](https://github.com/garethgreenaway)
- Fixed image parser when output includes a duration timestamp - [@RulerOf](https://github.com/RulerOf)
- Updated the test suites - [@RulerOf](https://github.com/RulerOf)

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
