### PR TITLE
 Make sure the /etc/sudoers.d directory exists

### DIFF
--- a/lib/kitchen/docker/helpers/dockerfile_helper.rb
+++ b/lib/kitchen/docker/helpers/dockerfile_helper.rb
@@ -143,6 +143,8 @@ module Kitchen
             RUN if ! getent passwd #{username}; then \
                   useradd -d #{homedir} -m -s /bin/bash -p '*' #{username}; \
                 fi
+            RUN mkdir -p /etc/sudoers.d
+            RUN chmod 0750 /etc/sudoers.d
             RUN echo "#{username} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/#{username}
             RUN echo "Defaults !requiretty" >> /etc/sudoers.d/#{username}
             RUN mkdir -p #{homedir}/.ssh


### PR DESCRIPTION
# Description
Make sure the /etc/sudoers.d directory exists before trying to write a file there.

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

`_fix_`

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
