### PR TITLE
Breaking rockylinux platform out

### DIFF
--- a/lib/kitchen/docker/helpers/dockerfile_helper.rb
+++ b/lib/kitchen/docker/helpers/dockerfile_helper.rb
@@ -34,12 +34,14 @@ module Kitchen
             gentoo_paludis_platform
           when 'opensuse/tumbleweed', 'opensuse/leap', 'opensuse', 'sles'
             opensuse_platform
-          when 'rhel', 'centos', 'oraclelinux', 'amazonlinux', 'rockylinux'
+          when 'rhel', 'centos', 'oraclelinux', 'amazonlinux'
             rhel_platform
           when 'centosstream'
             centosstream_platform
           when 'almalinux'
             almalinux_platform
+          when 'rockylinux'
+            rockyinux_platform
           when 'photon'
             photonos_platform
           else
@@ -131,6 +133,16 @@ module Kitchen
         end
 
         def almalinux_platform
+          <<-CODE
+            ENV container docker
+            RUN yum clean all
+            RUN yum install -y sudo openssh-server openssh-clients which
+            RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
+            RUN [ -f "/etc/ssh/ssh_host_dsa_key" ] || ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key -N ''
+          CODE
+        end
+
+        def rockylinux_platform
           <<-CODE
             ENV container docker
             RUN yum clean all

--- a/lib/kitchen/docker/helpers/dockerfile_helper.rb
+++ b/lib/kitchen/docker/helpers/dockerfile_helper.rb
@@ -41,7 +41,7 @@ module Kitchen
           when 'almalinux'
             almalinux_platform
           when 'rockylinux'
-            rockyinux_platform
+            rockylinux_platform
           when 'photon'
             photonos_platform
           else


### PR DESCRIPTION
# Description
Breaking rockylinux out into it's own platform, Curl is already available in 8 and 9 containers and installing curl on 9 causes a conflict with the already installed curl-minimal package.

## Type of Change

- `_fix_`

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
