### PR TITLE
fix: parse_image_id: Process "docker build" output in reverse line order

### DIFF
--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -25,7 +25,7 @@ module Kitchen
         include Kitchen::Docker::Helpers::ContainerHelper
 
         def parse_image_id(output)
-          output.each_line do |line|
+          output.split("\n").reverse_each do |line|
             if line =~ /writing image (sha256:[[:xdigit:]]{64})(?: \d*\.\ds)? done/i
               img_id = line[/writing image (sha256:[[:xdigit:]]{64})(?: \d*\.\ds)? done/i,1]
               return img_id


### PR DESCRIPTION
When using a custom dockerfile which installs Python modules using pip, the output will sometimes contain the line:

```
Successfully built module_name
```

Since this matches one of the regexes in parse_image_id, it causes the module name to be incorrectly identified as the image ID, which will cause kitchen-docker to fail the "docker run" as it will not have a valid Docker image ID.

This commit processes the "docker build" output in reverse line order, which will ensure that the correct line is matched.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [X] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
