### PR TITLE
Fix: Switch to buildx builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,17 +75,16 @@ jobs:
       matrix:
         suite:
           - default
-          - no_build_context
+          - no-build-context
           - arm64
           - amd64
           - inspec
         os:
           - amazonlinux-2
-          - ubuntu-18.04
-          - ubuntu-20.04
+          - ubuntu-1804
+          - ubuntu-2004
           - fedora-latest
           - centos-7
-          - centos-8
           - oraclelinux-7
           - rockylinux-8
           - debian-11
@@ -98,6 +97,8 @@ jobs:
         with:
           ruby-version: "3.1"
           bundler-cache: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - run: bundle exec kitchen test ${{ matrix.suite }}-${{ matrix.os }}
@@ -111,7 +112,7 @@ jobs:
       matrix:
         suite:
           - capabilities
-        os: [debian-11, ubuntu-18.04, ubuntu-20.04]
+        os: [debian-11, ubuntu-1804, ubuntu-2004]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,17 @@ jobs:
 
   integration-linux:
     name: Linux ${{matrix.suite}} ${{matrix.os}}
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: unit
     strategy:
       fail-fast: false
       matrix:
-        suite: [default, context, capabilities, arm64, amd64, inspec]
+        suite:
+          - default
+          - no_build_context
+          - arm64
+          - amd64
+          - inspec
         os:
           - amazonlinux-2
           - ubuntu-18.04
@@ -83,10 +88,30 @@ jobs:
           - centos-8
           - oraclelinux-7
           - rockylinux-8
-          - debian-9
-          - debian-10
+          - debian-11
+          - debian-12
           - opensuse-15
           - dockerfile
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+          bundler-cache: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - run: bundle exec kitchen test ${{ matrix.suite }}-${{ matrix.os }}
+
+  integration-capabilities:
+    name: Linux ${{matrix.suite}} ${{matrix.os}}
+    runs-on: ubuntu-latest
+    needs: unit
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - capabilities
+        os: [debian-11, ubuntu-18.04, ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
         with:
           ruby-version: "3.1"
           bundler-cache: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - run: bundle exec kitchen test ${{ matrix.suite }}-${{ matrix.os }}
 
   integration-linux:
@@ -91,4 +93,6 @@ jobs:
         with:
           ruby-version: "3.1"
           bundler-cache: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - run: bundle exec kitchen test ${{ matrix.suite }}-${{ matrix.os }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,10 @@
+require:
+  - chefstyle
+
+AllCops:
+  TargetRubyVersion: 3.1
+  Include:
+    - "**/*.rb"
+  Exclude:
+    - "vendor/**/*"
+    - "spec/**/*"

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -24,8 +24,8 @@ platforms:
   - name: centos-7
   - name: oraclelinux-7
   - name: rockylinux-8
-  - name: debian-9
-  - name: debian-10
+  - name: debian-11
+  - name: debian-12
   - name: opensuse-15
     driver:
       image: opensuse/leap:15
@@ -38,9 +38,7 @@ platforms:
 
 suites:
   - name: default
-    excludes: [arch, debian-9]
-  - name: context
-    excludes: [arch, debian-9]
+  - name: no_build_context
     driver:
       build_context: false
   - name: capabilities
@@ -52,7 +50,6 @@ suites:
       cap_drop:
         - NET_ADMIN
   - name: arm64
-    excludes: [debian-9]
     driver:
       docker_platform: linux/arm64
   - name: amd64

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -42,7 +42,7 @@ suites:
     driver:
       build_context: false
   - name: capabilities
-    includes: [debian-10, ubuntu-18.04, ubuntu-20.04]
+    includes: [debian-11, ubuntu-18.04, ubuntu-20.04]
     driver:
       provision_command:
         - curl -L https://www.chef.io/chef/install.sh | bash

--- a/lib/kitchen/docker/helpers/cli_helper.rb
+++ b/lib/kitchen/docker/helpers/cli_helper.rb
@@ -19,11 +19,13 @@ require 'kitchen/shell_out'
 module Kitchen
   module Docker
     module Helpers
+      # rubocop:disable Metrics/ModuleLength, Style/Documentation
       module CliHelper
         include Configurable
         include Logging
         include ShellOut
 
+        # rubocop:disable Metrics/AbcSize
         def docker_command(cmd, options={})
           docker = config[:binary].dup
           docker << " -H #{config[:socket]}" if config[:socket]
@@ -35,8 +37,10 @@ module Kitchen
           logger.debug("docker_command: #{docker} #{cmd} shell_opts: #{docker_shell_opts(options)}")
           run_command("#{docker} #{cmd}", docker_shell_opts(options))
         end
+        # rubocop:enable Metrics/AbcSize
 
         # Copied from kitchen because we need stderr
+        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         def run_command(cmd, options = {})
           if options.fetch(:use_sudo, false)
             cmd = "#{options.fetch(:sudo_command, "sudo -E")} #{cmd}"
@@ -55,7 +59,9 @@ module Kitchen
           error.extend(Kitchen::Error)
           raise
         end
+        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength, Metrics/AbcSize
         def build_run_command(image_id, transport_port = nil)
           cmd = 'run -d'
           cmd << ' -i' if config[:interactive]
@@ -91,7 +97,9 @@ module Kitchen
           logger.debug("build_run_command: #{cmd}")
           cmd
         end
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength, Metrics/AbcSize
 
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
         def build_exec_command(state, command)
           cmd = 'exec'
           cmd << ' -d' if config[:detach]
@@ -106,6 +114,7 @@ module Kitchen
           logger.debug("build_exec_command: #{cmd}")
           cmd
         end
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/AbcSize
 
         def build_copy_command(local_file, remote_file, opts = {})
           cmd = 'cp'
@@ -154,6 +163,7 @@ module Kitchen
         # @since 2.5.0
         # @param config [nil, String, Array, Hash] Config data to convert.
         # @return [String]
+        # rubocop:disable Metrics/CyclomaticComplexity
         def config_to_options(config)
           case config
           when nil
@@ -166,7 +176,9 @@ module Kitchen
             config.map { |k, v| Array(v).map { |c| "--#{k}=#{Shellwords.escape(c)}" }.join(' ') }.join(' ')
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
       end
+      # rubocop:enable Metrics/ModuleLength, Style/Documentation
     end
   end
 end

--- a/lib/kitchen/docker/helpers/container_helper.rb
+++ b/lib/kitchen/docker/helpers/container_helper.rb
@@ -25,6 +25,7 @@ require_relative 'cli_helper'
 module Kitchen
   module Docker
     module Helpers
+      # rubocop:disable Metrics/ModuleLength, Style/Documentation
       module ContainerHelper
         include Configurable
         include Kitchen::Docker::Helpers::CliHelper
@@ -95,6 +96,7 @@ module Kitchen
           raise "Failed to copy file #{local_file} to container. #{e}"
         end
 
+        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         def container_env_variables(state)
           # Retrieves all environment variables from inside container
           vars = {}
@@ -112,6 +114,7 @@ module Kitchen
 
           vars
         end
+        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
         def replace_env_variables(state, str)
           if str.include?('$env:')
@@ -167,6 +170,7 @@ module Kitchen
           env_variables
         end
       end
+      # rubocop:enable Metrics/ModuleLength, Style/Documentation
     end
   end
 end

--- a/test/integration/capabilities/disabled/capabilities_drop_spec.rb
+++ b/test/integration/capabilities/disabled/capabilities_drop_spec.rb
@@ -1,4 +1,6 @@
 #
+# Copyright 2016, Noah Kantrowitz
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,10 +14,11 @@
 # limitations under the License.
 #
 
-case RbConfig::CONFIG['host_os']
-when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
-  set :backend, :cmd
-  set :os, :family => 'windows'
-else
-  set :backend, :exec
-end
+# Disable now busser-serever is gone.
+# require 'serverspec'
+# set :backend, :exec
+
+# describe command('/sbin/ifconfig eth0 multicast') do
+#   its(:exit_status) { is_expected.to_not eq 0 }
+#   its(:stderr) { is_expected.to match /Operation not permitted/ }
+# end

--- a/test/integration/default/disabled/default_spec.rb
+++ b/test/integration/default/disabled/default_spec.rb
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 
-require 'serverspec'
-set :backend, :exec
+# Disable now busser-serever is gone.
+# require 'serverspec'
+# require 'spec_helper'
 
-describe command('/sbin/ifconfig eth0 multicast') do
-  its(:exit_status) { is_expected.to_not eq 0 }
-  its(:stderr) { is_expected.to match /Operation not permitted/ }
-end
+# # Just make sure the image launched and is reachable.
+# describe command('true') do
+#   its(:exit_status) { is_expected.to eq 0 }
+# end

--- a/test/integration/default/disabled/spec_helper.rb
+++ b/test/integration/default/disabled/spec_helper.rb
@@ -1,6 +1,4 @@
 #
-# Copyright 2016, Noah Kantrowitz
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,10 +12,10 @@
 # limitations under the License.
 #
 
-require 'serverspec'
-require 'spec_helper'
-
-# Just make sure the image launched and is reachable.
-describe command('true') do
-  its(:exit_status) { is_expected.to eq 0 }
-end
+# case RbConfig::CONFIG['host_os']
+# when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+#   set :backend, :cmd
+#   set :os, :family => 'windows'
+# else
+#   set :backend, :exec
+# end

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -22,7 +22,7 @@ require 'simplecov'
 # Check for coverage stuffs
 formatters = []
 
-if ENV['CODECOV_TOKEN'] || ENV['TRAVIS']
+if ENV['CODECOV_TOKEN'] || ENV['CI']
   require 'codecov'
   formatters << SimpleCov::Formatter::Codecov
 end


### PR DESCRIPTION
# Description

Switch to the buildx builder in GitHub Actions

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
