### PR TITLE
fix: Support docker build output for Docker Desktop v4.31

### DIFF
--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -35,6 +35,11 @@ module Kitchen
               img_id = line.split(/\s+/).last
               return img_id
             end
+            # Docker ~v4.31 support
+            if line =~ /naming to moby-dangling@(sha256:[[:xdigit:]]{64})(?: \d*\.\ds)? done/i
+              img_id = line[/naming to moby-dangling@(sha256:[[:xdigit:]]{64})(?: \d*\.\ds)? done/i, 1]
+              return img_id
+            end
           end
           raise ActionFailed, "Could not parse Docker build output for image ID"
         end


### PR DESCRIPTION
# Description

Add image build parser that works for Docker Desktop v4.31.0

## Issues Resolved

resolves #419

## Type of Change

fix

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
