### PR TITLE
fix: resolve gemspec load path and refactor proxy config method

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   lint-unit:
-    uses: test-kitchen/.github/.github/workflows/lint-unit.yml@main
+    uses: test-kitchen/.github/.github/workflows/lint-unit.yml@v0.2.3
 
   integration-windows:
     name: Windows ${{matrix.suite}} ${{matrix.os}}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   lint-unit:
-    uses: test-kitchen/.github/.github/workflows/lint-unit.yml@v0.2.3
+    uses: test-kitchen/.github/.github/workflows/lint-unit.yml@main
 
   integration-windows:
     name: Windows ${{matrix.suite}} ${{matrix.os}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -438,7 +438,7 @@ generated key pair.
 
 ## [0.8.1](https://github.com/test-kitchen/kitchen-docker/compare/v0.8.0...v0.8.1) (2013-10-26)
 
-* https://github.com/portertech/kitchen-docker/graphs/contributors ([70a2722](https://github.com/test-kitchen/kitchen-docker/commit/70a2722))
+* <https://github.com/portertech/kitchen-docker/graphs/contributors> ([70a2722](https://github.com/test-kitchen/kitchen-docker/commit/70a2722))
 * force /sbin/initctl symlink, minor version bump ([8ccd795](https://github.com/test-kitchen/kitchen-docker/commit/8ccd795))
 
 ## [0.8.0](https://github.com/test-kitchen/kitchen-docker/compare/v0.8.0.beta...v0.8.0) (2013-10-26)

--- a/lib/kitchen/docker/helpers/container_helper.rb
+++ b/lib/kitchen/docker/helpers/container_helper.rb
@@ -220,8 +220,6 @@ module Kitchen
           docker_command("rm #{container_id}")
         end
 
-        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-
         # Dockerfile ENV lines carrying the configured proxy settings.
         #
         # Each is emitted in both lower and upper case, because different tools
@@ -234,13 +232,17 @@ module Kitchen
           end.join
         end
 
+        # ENV lines for one proxy setting, in both spellings.
+        #
+        # @param proxy_type [Symbol] +:http_proxy+, +:https_proxy+, or
+        #   +:no_proxy+
+        # @return [String] two ENV lines, or empty when that proxy is unset
         def proxy_env_vars(proxy_type)
           return "" unless config[proxy_type]
 
           value = config[proxy_type]
           "ENV #{proxy_type}=#{value}\nENV #{proxy_type.upcase}=#{value}\n"
         end
-        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
       end
       # rubocop:enable Metrics/ModuleLength
     end

--- a/lib/kitchen/docker/helpers/container_helper.rb
+++ b/lib/kitchen/docker/helpers/container_helper.rb
@@ -229,23 +229,16 @@ module Kitchen
         #
         # @return [String] the ENV lines, empty when no proxy is configured
         def dockerfile_proxy_config
-          env_variables = ""
-          if config[:http_proxy]
-            env_variables << "ENV http_proxy=#{config[:http_proxy]}\n"
-            env_variables << "ENV HTTP_PROXY=#{config[:http_proxy]}\n"
-          end
+          %i{http_proxy https_proxy no_proxy}.map do |proxy_type|
+            proxy_env_vars(proxy_type)
+          end.join
+        end
 
-          if config[:https_proxy]
-            env_variables << "ENV https_proxy=#{config[:https_proxy]}\n"
-            env_variables << "ENV HTTPS_PROXY=#{config[:https_proxy]}\n"
-          end
+        def proxy_env_vars(proxy_type)
+          return "" unless config[proxy_type]
 
-          if config[:no_proxy]
-            env_variables << "ENV no_proxy=#{config[:no_proxy]}\n"
-            env_variables << "ENV NO_PROXY=#{config[:no_proxy]}\n"
-          end
-
-          env_variables
+          value = config[proxy_type]
+          "ENV #{proxy_type}=#{value}\nENV #{proxy_type.upcase}=#{value}\n"
         end
         # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
       end


### PR DESCRIPTION
- Change File.expand_path to use __dir__ instead of __FILE__ in gemspec to properly resolve the lib directory path
- Extract repetitive proxy environment variable logic into separate proxy_env_vars helper method
- Reduce dockerfile_proxy_config ABC size from 24.21 to below threshold
- Reduce method length from 14 lines to 4 lines to meet style guidelines

Signed-off-by: Dan Webb <dan.webb@damacus.io>
