### PR TITLE
fix: tolerate stderr warnings when parsing docker run container id

### DIFF
--- a/lib/kitchen/docker/helpers/container_helper.rb
+++ b/lib/kitchen/docker/helpers/container_helper.rb
@@ -31,11 +31,16 @@ module Kitchen
         include Kitchen::Docker::Helpers::CliHelper
 
         def parse_container_id(output)
-          container_id = output.chomp
-
-          unless [12, 64].include?(container_id.size)
-            raise ActionFailed, "Could not parse Docker run output for container ID"
+          # Docker prints the container ID to stdout, but on some hosts (notably
+          # rootless Docker) warnings such as "WARNING: IPv4 forwarding is disabled"
+          # are emitted on stderr and can be interleaved into the captured output.
+          # Rather than assuming the whole blob is the ID, scan the lines and return
+          # the last bare 12- or 64-character hex token.
+          container_id = output.to_s.split("\n").map(&:strip).reverse.find do |line|
+            line.match?(/\A[0-9a-f]{12}(?:[0-9a-f]{52})?\z/)
           end
+
+          raise ActionFailed, "Could not parse Docker run output for container ID" unless container_id
 
           container_id
         end

--- a/test/spec/docker_spec.rb
+++ b/test/spec/docker_spec.rb
@@ -61,4 +61,44 @@ describe Kitchen::Driver::Docker do
       it { is_expected.to eq '--foo=bar\\ two --other=baz' }
     end # /context with a hash of strings with spaces
   end # /describe #config_to_options
+
+  describe "#parse_container_id" do
+    subject { described_class.new.send(:parse_container_id, output) }
+
+    # 64 hex chars (full id) and 12 hex chars (short id)
+    let(:container_id) { "0123456789abcdef" * 4 }
+    let(:short_id) { "abcdef123456" }
+
+    # The warning Docker emits to stderr on rootless hosts. CliHelper#run_command
+    # returns sh.stdout + sh.stderr, so this can be interleaved with the id.
+    let(:warning) { "WARNING: IPv4 forwarding is disabled. Networking will not work." }
+
+    context "with a bare 64-character container id" do
+      let(:output) { container_id }
+      it { is_expected.to eq(container_id) }
+    end # /context with a bare 64-character container id
+
+    context "with a bare 12-character short id" do
+      let(:output) { short_id }
+      it { is_expected.to eq(short_id) }
+    end # /context with a bare 12-character short id
+
+    context "with a trailing stderr warning after the container id" do
+      let(:output) { "#{container_id}\n#{warning}\n" }
+      it { is_expected.to eq(container_id) }
+    end # /context with a trailing stderr warning after the container id
+
+    context "with a leading stderr warning before the container id" do
+      let(:output) { "#{warning}\n#{container_id}\n" }
+      it { is_expected.to eq(container_id) }
+    end # /context with a leading stderr warning before the container id
+
+    context "with output containing no container id" do
+      let(:output) { "#{warning}\nno container id here" }
+
+      it "raises ActionFailed" do
+        expect { subject }.to raise_error(Kitchen::ActionFailed, /Could not parse Docker run output/)
+      end
+    end # /context with output containing no container id
+  end # /describe #parse_container_id
 end


### PR DESCRIPTION
## Summary

`kitchen create` with the Docker driver fails on hosts where `docker run` writes
warnings to **stderr**. The driver captures stdout and stderr **combined**, but
`parse_container_id` assumed the whole captured blob was the container ID, so any
extra stderr line made it raise `Could not parse Docker run output for container ID`.

This is increasingly common with **rootless Docker**, which prints
`WARNING: IPv4 forwarding is disabled. Networking will not work.` on `docker run`.

## Reproduction

On a host running rootless Docker (or any daemon that warns on `docker run`), the
container ID is written to **stdout** and the warning to **stderr**. Isolating each
stream shows where each part comes from:

```console
# stdout only (stderr hidden) → the container id
$ docker run -d --rm ubuntu:24.04 sleep 2 2>/dev/null
81086017af8445096d19e795bbaa4bbebb3dbd4a1e8f27c92d5c19080178e1a0

# stderr only (stdout hidden) → the warning
$ docker run -d --rm ubuntu:24.04 sleep 2 1>/dev/null
WARNING: IPv4 forwarding is disabled. Networking will not work.
```

The driver does **not** see these separately. `CliHelper#run_command` returns
`sh.stdout + sh.stderr`, so the string actually handed to `parse_container_id`
contains **both** the id and the warning:

```
81086017af8445096d19e795bbaa4bbebb3dbd4a1e8f27c92d5c19080178e1a0
WARNING: IPv4 forwarding is disabled. Networking will not work.
```

`kitchen create` then fails in `parse_container_id`.

## Root cause

The old implementation chomped that whole blob and required its length to be
exactly 12 or 64 characters, so the extra stderr line raised:

```ruby
container_id = output.chomp
unless [12, 64].include?(container_id.size)
  raise ActionFailed, "Could not parse Docker run output for container ID"
end
```

## Fix

Scan the output lines and return the last bare 12- or 64-character hex token,
tolerating stderr noise interleaved before or after the id (rootless
IPv4-forwarding warnings, deprecation notices, etc.):

```ruby
container_id = output.to_s.split("\n").map(&:strip).reverse.find do |line|
  line.match?(/\A[0-9a-f]{12}(?:[0-9a-f]{52})?\z/)
end

raise ActionFailed, "Could not parse Docker run output for container ID" unless container_id

container_id
```

## Tests

Adds RSpec coverage for `#parse_container_id` in `test/spec/docker_spec.rb`:

1. a bare 64-character ID still parses;
2. a bare 12-character short ID still parses;
3. a stderr warning **after** the id (the `sh.stdout + sh.stderr` order) parses to just the id;
4. a stderr warning **before** the id parses to just the id;
5. output with no hex-id line still raises `ActionFailed`.

`bundle exec rake test` (13 examples, 0 failures) and `bundle exec chefstyle`
(21 files inspected, no offenses) both pass on Ruby 3.1.

This affects the growing set of rootless-Docker users.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
