### PR TITLE
Avoid curl conflict with RHEL ubi in dockerfile helper

### DIFF
--- a/lib/kitchen/docker/helpers/dockerfile_helper.rb
+++ b/lib/kitchen/docker/helpers/dockerfile_helper.rb
@@ -111,7 +111,9 @@ module Kitchen
           <<-CODE
             ENV container=docker
             RUN yum clean all
-            RUN yum install -y sudo openssh-server openssh-clients which curl
+            RUN yum install -y which
+            RUN which curl || yum install -y curl
+            RUN yum install -y sudo openssh-server openssh-clients
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
           CODE
         end

--- a/lib/kitchen/docker/helpers/dockerfile_helper.rb
+++ b/lib/kitchen/docker/helpers/dockerfile_helper.rb
@@ -111,9 +111,8 @@ module Kitchen
           <<-CODE
             ENV container=docker
             RUN yum clean all
-            RUN yum install -y which
+            RUN yum install -y sudo openssh-server openssh-clients which
             RUN which curl || yum install -y curl
-            RUN yum install -y sudo openssh-server openssh-clients
             RUN [ -f "/etc/ssh/ssh_host_rsa_key" ] || ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N ''
           CODE
         end

--- a/spec/dockerfile_helper_spec.rb
+++ b/spec/dockerfile_helper_spec.rb
@@ -61,9 +61,10 @@ describe Kitchen::Docker::Helpers::DockerfileHelper do
       expect(result).not_to include("--allowerasing")
     end
 
-    it "installs required packages including curl" do
+    it "installs required packages including curl if needed" do
       result = helper.rhel_platform
-      expect(result).to include("sudo openssh-server openssh-clients which curl")
+      expect(result).to include("sudo openssh-server openssh-clients which")
+      expect(result).to include("which curl || yum install -y curl")
     end
   end
 


### PR DESCRIPTION
# Description

Seems RHEL9 ubi (and likely others) ships with a curl-minimal package already. Trying to install `curl` throws a conflict with that. This change checks for curl's existence and only installs it if needed.

## Issues Resolved

#457 

## Type of Change

fix

## Check List

- [X ] New functionality includes tests
- [X ] All tests pass
- [ X] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
