### PR TITLE
Fix typos

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ require "rspec/its"
 require "kitchen/driver/docker"
 
 RSpec.configure do |config|
-  # Basic configuraiton
+  # Basic configuration
   config.run_all_when_everything_filtered = true
   config.filter_run(:focus)
 


### PR DESCRIPTION
Fixes spelling mistakes found with the [`typos`](https://github.com/crate-ci/typos) linter.

Changes are limited to comments, documentation, and test descriptions -- no functional changes.

Files touched:
- spec/spec_helper.rb