### PR TITLE
Require Ruby 3.1+ and modernize CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,6 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.1
-  Include:
-    - "**/*.rb"
   Exclude:
     - "vendor/**/*"
     - "spec/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.1
+  Include:
+    - "**/*.rb"
   Exclude:
     - "vendor/**/*"
     - "spec/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
-gemspec
-
+gemspec development_group: :test
 group :development do
   # Integration testing gems.
   gem "kitchen-cinc-auditor", git: "https://github.com/test-kitchen/kitchen-cinc-auditor.git"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ group :development do
 end
 
 group :test do
-  gem "bundler"
   gem "rake"
   gem "rspec", "~> 3.2"
   gem "rspec-its", "~> 2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Kitchen-Docker
 
-[![Build Status](https://travis-ci.org/test-kitchen/kitchen-docker.svg?branch=master)](https://travis-ci.org/test-kitchen/kitchen-docker)
 [![Gem Version](https://img.shields.io/gem/v/kitchen-docker.svg)](https://rubygems.org/gems/kitchen-docker)
 [![Coverage](https://img.shields.io/codecov/c/github/test-kitchen/kitchen-docker.svg)](https://codecov.io/github/test-kitchen/kitchen-docker)
 [![License](https://img.shields.io/badge/license-Apache_2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)

--- a/README.md
+++ b/README.md
@@ -666,6 +666,6 @@ limitations under the License.
 [docker_installation]:    https://docs.docker.com/installation/#installation
 [docker_index]:           https://index.docker.io/
 [test_kitchen_docs]:      https://kitchen.ci/docs/getting-started/introduction/
-[chef_omnibus_dl]:        https://downloads.chef.io/chef-client/
+[chef_omnibus_dl]:        https://downloads.chef.io/tools/infra-client
 [cpu_shares]:             https://docs.fedoraproject.org/en-US/Fedora/17/html/Resource_Management_Guide/sec-cpu.html
 [memory_limit]:           https://docs.fedoraproject.org/en-US/Fedora/17/html/Resource_Management_Guide/sec-memory.html

--- a/kitchen-docker.gemspec
+++ b/kitchen-docker.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "kitchen/docker/docker_version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "kitchen-docker"
+  spec.name = "kitchen-docker"
   spec.required_ruby_version = ">= 3.1"
   spec.version       = Kitchen::Docker::DOCKER_VERSION
   spec.authors       = ["Sean Porter"]

--- a/kitchen-docker.gemspec
+++ b/kitchen-docker.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{A Docker Driver for Test Kitchen}
   spec.summary       = spec.description
   spec.homepage      = "https://github.com/test-kitchen/kitchen-docker"
-  spec.license       = "Apache 2.0"
+  spec.license       = "Apache-2.0"
 
   spec.files         = `git ls-files`.split($/)
   spec.require_paths = ["lib"]

--- a/kitchen-docker.gemspec
+++ b/kitchen-docker.gemspec
@@ -4,6 +4,7 @@ require "kitchen/docker/docker_version"
 
 Gem::Specification.new do |spec|
   spec.name          = "kitchen-docker"
+  spec.required_ruby_version = ">= 3.1"
   spec.version       = Kitchen::Docker::DOCKER_VERSION
   spec.authors       = ["Sean Porter"]
   spec.email         = ["portertech@gmail.com"]


### PR DESCRIPTION
Standardizes the Ruby requirement and CI across the test-kitchen org.

### Changes
- **Ruby requirement**: `required_ruby_version = ">= 3.1"` in the gemspec.
- **`.rubocop.yml`**: standardized on `cookstyle/chefstyle` with `TargetRubyVersion: 3.1`, matching test-kitchen. Many repos still required the standalone `chefstyle` gem, which no longer loads — cookstyle could not run at all before this.
- **CI**: unit tests on **3.1, 3.2, 3.3, 3.4, 4.0**; `cookstyle --chefstyle` on **3.1**.
- **Bundler**: added the `cookstyle` group where missing, so `bundle exec cookstyle` resolves in CI.
- **Cookstyle**: applied `cookstyle --chefstyle -a` autocorrections; `cookstyle --chefstyle` is now clean.
- **Dead linters removed** where present (`cane`, `tailor`, `finstyle`, standalone `chefstyle`). These are unmaintained and fail on modern Ruby (`cane` calls `File.exists?`, removed in Ruby 4.0; `tailor` needs `ostruct`, no longer a default gem). Cookstyle supersedes them.

Comment/config changes plus mechanical style autocorrections; no intentional behavior changes.
