### PR TITLE
Docs: document the last four options and split contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to kitchen-docker
+
+Thanks for your interest in improving kitchen-docker. Bug reports, feature requests, and pull requests are all welcome.
+
+## Reporting issues
+
+* Source is hosted on [GitHub](https://github.com/test-kitchen/kitchen-docker).
+* Report issues, questions, and feature requests on
+  [GitHub Issues](https://github.com/test-kitchen/kitchen-docker/issues).
+
+For bugs, please include:
+
+- the version of kitchen-docker and Test Kitchen you are using
+- your Docker version and host platform (Linux, macOS, Windows, or a remote
+  daemon)
+- your `kitchen.yml`
+- the output of the failing command, ideally with `-l debug`
+
+The driver builds an image and then runs a container, so the generated
+Dockerfile and the `docker run` command line from a debug run are usually the
+most useful things to attach.
+
+## Development setup
+
+```sh
+git clone https://github.com/test-kitchen/kitchen-docker.git
+cd kitchen-docker
+bundle install
+```
+
+## Running the tests
+
+```sh
+bundle exec rake          # unit tests and linting
+bundle exec rake spec     # unit tests only
+bundle exec rake style    # Cookstyle / RuboCop only
+```
+
+To run a single spec file:
+
+```sh
+bundle exec rspec spec/kitchen/driver/docker_spec.rb
+```
+
+Many style offenses can be corrected automatically:
+
+```sh
+bundle exec cookstyle -a
+```
+
+The unit tests assert on the Dockerfile and command lines the driver generates.
+They do not talk to a Docker daemon, so they run without Docker installed.
+
+## Manual testing
+
+Because the unit tests only check generated commands, changes that affect image
+build or container run should also be exercised against a real daemon.
+
+Worth exercising separately, since they take different paths through the driver:
+
+- **Linux and Windows containers**, which generate different Dockerfiles
+- **a remote daemon**, via `socket`, as well as the local default
+- **`build_context`**, which changes what is sent to the daemon
+- **privileged options** such as `cap_add`, `security_opt`, and `devices`
+
+## Submitting changes
+
+1. Fork the repository.
+2. Create a feature branch off `main`.
+3. Make your change, adding or updating tests to cover it.
+4. Make sure `bundle exec rake` passes.
+5. Push the branch to your fork and open a pull request.
+
+Please keep pull requests focused on a single change — it makes review much
+faster. Update the documentation in `README.md` when you add or change a
+configuration option.
+
+## Release process
+
+Releases are handled by the maintainers.
+
+1. Update `lib/kitchen/docker/docker_version.rb` with the new version.
+2. Update `CHANGELOG.md`.
+3. Merge to `main`; the publish workflow builds the gem and pushes it to
+   RubyGems.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ A Test Kitchen Driver and Transport for Docker.
 
 ## Installation and Setup
 
+This driver ships as part of [Cinc Workstation](https://cinc.sh/start/workstation/).
+If you have Cinc Workstation installed, there is nothing else to install. To
+install it into a standalone Ruby:
+
+```sh
+gem install kitchen-docker
+```
+
+The examples below use the `cinc` commands. Everything here works identically
+with Chef Workstation — see [Using with Chef](#using-with-chef).
+
 Please read the Test Kitchen [docs][test_kitchen_docs] for more details.
 
 Example (Linux) `.kitchen.local.yml`:
@@ -401,6 +412,17 @@ Examples:
   https_proxy: http://proxy.host.com:8080
 ```
 
+### no\_proxy
+
+Sets a proxy exclusion list for the suite container using the `no_proxy`
+environment variable. Used alongside `http_proxy` and `https_proxy`.
+
+Examples:
+
+```yaml
+  no_proxy: localhost,127.0.0.1,.internal.example.com
+```
+
 ### forward
 
 Set suite container port(s) to forward to the host machine. You may specify
@@ -613,6 +635,45 @@ Examples:
   use_internal_docker_network: true
 ```
 
+### add\_host
+
+Adds entries to the container's `/etc/hosts`, as a map of hostname to IP
+address. Each entry becomes a `--add-host` argument.
+
+Examples:
+
+```yaml
+  add_host:
+    db.internal: 10.0.0.5
+    cache.internal: 10.0.0.6
+```
+
+### gpus
+
+Requests GPU devices for the container, passed through as `--gpus`. Requires a
+Docker installation configured for GPU access.
+
+Examples:
+
+```yaml
+  gpus: all
+```
+
+```yaml
+  gpus: '"device=0,1"'
+```
+
+### detach
+
+Runs the container detached, with `-d`. The driver normally manages this itself;
+set it only if you know you need it.
+
+Examples:
+
+```yaml
+  detach: true
+```
+
 ### docker_platform
 
 Configure the CPU platform (architecture) used by docker to build the image.
@@ -643,20 +704,30 @@ platforms it starts `/bin/bash --login -i`; on Windows platforms it starts
 `privileged` settings are honoured, so the shell matches the environment that
 Test Kitchen uses when it runs the provisioner.
 
-## Development
+## Using with Chef
 
-* Source hosted at [GitHub][repo]
-* Report issues/questions/feature requests on [GitHub Issues][issues]
+This driver is not tied to Cinc. It runs containers and does not itself install
+either distribution — that is the provisioner's job. If you use
+[Chef Workstation](https://www.chef.io/downloads/tools/workstation) rather than
+[Cinc Workstation](https://cinc.sh/start/workstation/), run `kitchen` instead of
+`cinc kitchen` and use `chef_infra` instead of `cinc_infra`:
 
-Pull requests are very welcome! Make sure your patches are well tested.
-Ideally create a topic branch for every separate change you make. For
-example:
+```yaml
+provisioner:
+  name: chef_infra
 
-1. Fork the repo
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Added some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
+verifier:
+  name: inspec
+```
+
+No driver configuration changes are needed.
+
+## Contributing
+
+Bug reports and pull requests are welcome on [GitHub][repo], and issues on
+[GitHub Issues][issues]. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for development setup, how to run the tests,
+and the release process.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -688,6 +688,55 @@ Examples:
   docker_platform: linux/amd64
 ```
 
+## Transport Configuration
+
+This gem also ships a `docker` transport, which runs commands inside the
+container with `docker exec` instead of connecting over SSH or WinRM. Set it
+alongside the driver:
+
+```yaml
+transport:
+  name: docker
+```
+
+These options go under `transport:` rather than `driver:`.
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `binary` | `docker` | Docker CLI binary used to run commands. |
+| `socket` | `$DOCKER_HOST`, else `unix:///var/run/docker.sock` (`npipe:////./pipe/docker_engine` on Windows) | Docker daemon to connect to. |
+| `username` | `kitchen` on Linux, unset on Windows | User that commands run as inside the container. |
+| `interactive` | `false` | Pass `-i` to `docker exec`, keeping stdin open. |
+| `tty` | `false` | Pass `-t` to `docker exec`, allocating a pseudo-TTY. |
+| `privileged` | `false` | Run commands with `--privileged`. |
+| `working_dir` | `nil` | Working directory inside the container, passed as `--workdir`. |
+| `temp_dir` | `/tmp`, or `$env:TEMP` on Windows | Directory inside the container used to stage files. |
+| `env_variables` | `nil` | Environment variables set for commands run in the container. |
+| `wait_for_transport` | `true` | Wait for the transport to become ready before continuing. Set to `false` for containers that do not stay up. |
+| `private_key` | `.kitchen/docker_id_rsa` | Private key used when the container is reached over SSH rather than `docker exec`. |
+| `public_key` | `.kitchen/docker_id_rsa.pub` | Matching public key. |
+
+### Connecting to a TLS-protected daemon
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `tls` | `false` | Use TLS when connecting to the daemon. |
+| `tls_verify` | `false` | Verify the daemon's certificate. |
+| `tls_cacert` | `nil` | Path to the CA certificate. |
+| `tls_cert` | `nil` | Path to the client certificate. |
+| `tls_key` | `nil` | Path to the client key. |
+
+```yaml
+transport:
+  name: docker
+  socket: tcp://docker.example.com:2376
+  tls: true
+  tls_verify: true
+  tls_cacert: ~/.docker/ca.pem
+  tls_cert: ~/.docker/cert.pem
+  tls_key: ~/.docker/key.pem
+```
+
 ## Logging into a container
 
 `kitchen login` opens an interactive shell inside a running container using the
@@ -703,6 +752,7 @@ platforms it starts `/bin/bash --login -i`; on Windows platforms it starts
 `powershell`. The transport's `username`, `working_dir`, `env_variables` and
 `privileged` settings are honoured, so the shell matches the environment that
 Test Kitchen uses when it runs the provisioner.
+
 
 ## Using with Chef
 


### PR DESCRIPTION
## What

Fills the last four gaps in the option documentation, adds Cinc framing, and moves contributor material into `CONTRIBUTING.md`.

## Why it's narrow

This README is thorough — **every option declared through `default_config` was already documented**, each with its own section and examples. I verified that rather than assuming it (my first check reported false negatives because the headings use escaped underscores like `### require\_chef\_omnibus` rather than backticks).

So there was no completeness problem to fix, and rewriting it would have thrown away a lot of good work.

## The four real gaps

Read from `config` in `cli_helper.rb` / `container_helper.rb` but never declared through the DSL:

- **`no_proxy`** — the one most worth having. `http_proxy` and `https_proxy` were both documented, but not the exclusion list, and setting a proxy without one is rarely what you want.
- **`add_host`** — `/etc/hosts` entries via `--add-host`
- **`gpus`** — GPU device requests via `--gpus`
- **`detach`** — runs the container with `-d`; documented with a note that the driver normally manages this itself

## Cinc framing

Cinc Workstation added as the primary install route, plus a "Using with Chef" section. Worth being explicit here that **this driver runs containers and doesn't install either distribution** — that's the provisioner's job — so the Cinc/Chef choice doesn't affect any driver setting.

## CONTRIBUTING.md

New file, absorbing the README's Development section. Adds issue-reporting guidance (the generated Dockerfile and `docker run` line from a debug run are the useful attachments), a note that the unit tests never contact a daemon so they run without Docker, and a manual-testing checklist for the paths that genuinely differ: Linux vs Windows containers, remote daemons via `socket`, `build_context`, and the privileged options.

Docs only — no code changes.