### PR TITLE
docs: fix YARD errors and reach 100% documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,7 +344,7 @@ generated key pair.
 * Add ENV['DOCKER_HOST'] as default socket and add docs ([#71](https://github.com/test-kitchen/kitchen-docker/pull/71)) ([7e42958](https://github.com/test-kitchen/kitchen-docker/commit/7e42958))
 * default run_command string concatenation ([354c537](https://github.com/test-kitchen/kitchen-docker/commit/354c537))
 * test instance_name, publish_all, and links. ([4a87141](https://github.com/test-kitchen/kitchen-docker/commit/4a87141))
-* redirect stderr & stdout, write out sudoers.d/#{username} ([03b2a30](https://github.com/test-kitchen/kitchen-docker/commit/03b2a30))
+* redirect stderr & stdout, write out `sudoers.d/#{username}` ([03b2a30](https://github.com/test-kitchen/kitchen-docker/commit/03b2a30))
 * minor version bump ([bdc10b4](https://github.com/test-kitchen/kitchen-docker/commit/bdc10b4))
 
 ## [1.5.0](https://github.com/test-kitchen/kitchen-docker/compare/v1.4.0...v1.5.0) (2014-07-09)

--- a/lib/kitchen/transport/docker.rb
+++ b/lib/kitchen/transport/docker.rb
@@ -93,7 +93,10 @@ module Kitchen
       end
 
       # A connection to one container.
-      class Connection < Kitchen::Transport::Docker::Connection
+      #
+      # The superclass is named in full rather than relying on Ruby resolving
+      # the bare `Connection` constant through this class's ancestors.
+      class Connection < Kitchen::Transport::Base::Connection
         # Include the InSpec patches to be able to execute tests on Windows containers
         include Kitchen::Docker::Helpers::InspecHelper
 
@@ -134,7 +137,13 @@ module Kitchen
           @container
         end
 
-        # (see Base::Connection#login_command)
+        # The command `kitchen login` execs to open a shell in the container.
+        #
+        # Documented here rather than inherited via `(see ...)`, because the
+        # superclass lives in the test-kitchen gem and YARD cannot resolve a
+        # reference into it from this project's docs.
+        #
+        # @return [Kitchen::LoginCommand] an interactive `docker exec` session
         def login_command
           argv = build_login_command
           LoginCommand.new(argv.first, argv.drop(1))

--- a/spec/transport_docker_spec.rb
+++ b/spec/transport_docker_spec.rb
@@ -28,6 +28,13 @@ describe Kitchen::Transport::Docker::Connection do
 
   subject(:connection) { described_class.new(options) }
 
+  # The class is declared inside `class Docker < Kitchen::Transport::Base`, so
+  # its superclass is reached through Ruby's ancestor constant lookup rather
+  # than being spelled out. Pin it, so the inheritance cannot drift.
+  it "inherits from the Test Kitchen base connection" do
+    expect(described_class.superclass).to be Kitchen::Transport::Base::Connection
+  end
+
   describe "#login_command" do
     subject(:login_command) { connection.login_command }
 


### PR DESCRIPTION
## Summary

`bundle exec rake doc` currently emits an error and a warning, and reports 98.91% coverage. This gets it to clean output at 100.00%.

The error mattered more than the percentage suggested: YARD's `ClassHandler` crashed partway through `lib/kitchen/transport/docker.rb` and **silently skipped the remainder of the class body**. YARD counted 71 methods where the file defines 78 — seven methods were missing from the generated docs entirely, and one of them was genuinely undocumented.

## Changes

**1. `lib/kitchen/transport/docker.rb` — self-referential superclass**

```ruby
class Connection < Kitchen::Transport::Docker::Connection
```

This is declared *inside* `class Docker < Kitchen::Transport::Base`, so at that point `Kitchen::Transport::Docker::Connection` does not exist yet. It resolved only because Ruby's constant lookup walks the enclosing class's ancestors and finds `Kitchen::Transport::Base::Connection`. Verified:

```
$ ruby -e 'require "kitchen/transport/docker"; p Kitchen::Transport::Docker::Connection.superclass'
Kitchen::Transport::Base::Connection
```

YARD resolves constants statically and cannot follow that, hence the crash. Now named in full. **Behaviour is unchanged** — a spec pins the superclass so the inheritance cannot drift.

**2. `CHANGELOG.md` — unescaped interpolation**

A bare `sudoers.d/#{username}` outside backticks. YARD's markdown pass treats `{...}` as cross-reference link syntax and warns it cannot resolve `username`. The identical text ten lines above is already in backticks and passes clean; this makes the two consistent.

**3. `lib/kitchen/transport/docker.rb` — undocumented `login_command`**

The method deferred with `# (see Base::Connection#login_command)`, but that target lives in the `test-kitchen` gem, which YARD does not parse. The reference resolved to nothing, so the method rendered with **no documentation at all**. Replaced with a real comment. This gap was invisible before, because the handler crash meant YARD never reached the method.

## Verification

| | Before | After |
| --- | --- | --- |
| `yard doc` errors | 1 | 0 |
| `yard doc` warnings | 1 | 0 |
| Methods parsed | 71 | 78 |
| Coverage | 98.91% | **100.00%** |

```
$ bundle exec rake          # style + unit
28 files inspected, no offenses detected
35 examples, 0 failures
```

No behaviour changes — documentation tooling and one characterization test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)