### PR TITLE
fix: find the container id in docker run output that also carries warnings

### DIFF
--- a/lib/kitchen/docker/helpers/container_helper.rb
+++ b/lib/kitchen/docker/helpers/container_helper.rb
@@ -34,16 +34,25 @@ module Kitchen
 
         # Pulls the container id out of `docker run` output.
         #
-        # Docker prints ids in short (12) or full (64) hex form; anything else
-        # means the output was not an id at all.
+        # Docker prints ids in short (12) or full (64) hex form, on their own
+        # line. The id is looked for line by line rather than by taking the whole
+        # output, because {CliHelper#run_command} returns stdout and stderr
+        # together and docker writes warnings to stderr on runs that otherwise
+        # succeed -- "WARNING: Published ports are discarded when using host
+        # network mode" whenever run_options sets --net=host, and "WARNING: No
+        # swap limit support" on hosts whose kernel lacks swap accounting.
+        # Treating the whole output as the id failed those runs *after* the
+        # container had been created, leaving it running and untracked.
         #
-        # @param output [String] the command output
+        # @param output [String] the command output, stdout and stderr together
         # @return [String] the container id
-        # @raise [Kitchen::ActionFailed] if no id could be parsed
+        # @raise [Kitchen::ActionFailed] if no id could be found
         def parse_container_id(output)
-          container_id = output.chomp
+          container_id = output.lines.map(&:chomp).find do |line|
+            [12, 64].include?(line.size) && line.match?(/\A[0-9a-f]+\z/)
+          end
 
-          unless [12, 64].include?(container_id.size)
+          if container_id.nil?
             raise ActionFailed, "Could not parse Docker run output for container ID"
           end
 

--- a/spec/container_helper_spec.rb
+++ b/spec/container_helper_spec.rb
@@ -30,18 +30,34 @@ describe Kitchen::Docker::Helpers::ContainerHelper do
         .to raise_error(Kitchen::ActionFailed, /Could not parse Docker run output/)
     end
 
+    it "fails loudly on empty output" do
+      expect { helper.parse_container_id("") }
+        .to raise_error(Kitchen::ActionFailed, /Could not parse Docker run output/)
+    end
+
+    it "does not mistake a hex-looking word inside a message for an id" do
+      # The id has to be the whole line. A warning that happens to contain a
+      # twelve-character hex word must not be read as a container id, or the
+      # driver would track a container that does not exist.
+      expect { helper.parse_container_id("WARNING: layer abcdef123456 was skipped\n") }
+        .to raise_error(Kitchen::ActionFailed, /Could not parse Docker run output/)
+    end
+
+    it "takes the id docker printed, not a later line" do
+      expect(helper.parse_container_id(DockerOutput::RUN_WITH_PULL_ON_STDERR))
+        .to eq DockerOutput::RUN_CONTAINER_ID
+    end
+
     # run_command returns stdout + stderr, and the parser requires the whole
     # combined string to be exactly the id. Anything docker writes to stderr on
     # a successful `run` therefore fails container creation, with an error that
     # blames parsing rather than naming the warning.
     it "finds the id when docker pulled the image and logged progress to stderr" do
-      pending "BUG: parse_container_id requires the entire output to be the id, so any stderr output fails the run"
       expect(helper.parse_container_id(DockerOutput::RUN_WITH_PULL_ON_STDERR))
         .to eq DockerOutput::RUN_CONTAINER_ID
     end
 
     it "finds the id when the kernel lacks swap accounting" do
-      pending "BUG: the 'No swap limit support' warning docker emits on many Linux hosts is concatenated onto the id"
       expect(helper.parse_container_id(DockerOutput::RUN_WITH_SWAP_WARNING))
         .to eq DockerOutput::RUN_CONTAINER_ID
     end


### PR DESCRIPTION
## The bug

`CliHelper#run_command` returns **stdout and stderr together** — deliberately, because Docker writes image ids and build progress to stderr. `parse_container_id` then required the *entire* combined string to be the id:

```ruby
container_id = output.chomp
unless [12, 64].include?(container_id.size)
  raise ActionFailed, "Could not parse Docker run output for container ID"
end
```

So any warning Docker writes to stderr on an otherwise **successful** run fails the parse — and it fails *after* the container has been created. The container keeps running, and Test Kitchen never records its id.

## Reproduced against Docker 29.7.2

Through the driver's own `run_container`, which is exactly what `Container::Linux#create` calls:

```
generated command: docker run -d -p 22 --net=host alpine:3.20 sleep 60

RESULT: Kitchen::ActionFailed
        Could not parse Docker run output for container ID

Container was created anyway; the driver just cannot see its id:
  running containers from this image: ["d14c67e5f76a"]
```

The string it was handed:

```ruby
"d14c67e5f76a...\nWARNING: Published ports are discarded when using host network mode\n"
```

**This is reachable through documented configuration.** The driver always publishes port 22 for Linux containers, so `run_options: --net=host` produces that warning on *every* create. `WARNING: No swap limit support` — standard on hosts whose kernel lacks swap accounting — arrives the same way.

## The fix

Look for the id line by line: the first line that is entirely 12 or 64 hexadecimal characters.

Deliberately still strict — the **whole line** must match, so a hex-looking word inside a longer message is not mistaken for an id, and output containing no id still raises rather than returning nil into `state[:container_id]`.

## Verified after the change

```
generated command: docker run -d -p 22 --net=host alpine:3.20 sleep 60
RESULT: succeeded, container id = 72f1963bcc7c762d5e112f11431b4de544c7e710b9d261186dabd6a61fab8828
```

Nothing left untracked. And across the output shapes:

```
swap limit warning     -> b89e1e8b0766
pull progress          -> b89e1e8b0766
clean output           -> b89e1e8b0766
short id               -> abc123abc123
```

## Specs

The two `pending` markers on this bug are removed. Added: empty output still raises, and a warning containing a 12-hex word is not read as an id.

```
$ bundle exec rake
42 files inspected, no offenses detected
260 examples, 0 failures, 8 pending
```

This branch is cut from `main`, so it still carries the pendings for the other
confirmed bugs (5 quoting, 1 env-var parsing, 2 ssh port). Each is fixed in its
own PR; the two that belong to *this* bug are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
