### PR TITLE
fix: split printenv output on the first equals sign only

### DIFF
--- a/lib/kitchen/docker/helpers/container_helper.rb
+++ b/lib/kitchen/docker/helpers/container_helper.rb
@@ -159,7 +159,14 @@ module Kitchen
           else
             cmd = build_exec_command(state, "printenv")
             stdout = docker_command(cmd, suppress_output: !logger.debug?).strip
-            stdout.split("\n").each { |line| vars[line.split("=")[0]] = line.split("=")[1] }
+            # printenv writes NAME=VALUE, and values routinely contain "=" --
+            # LS_COLORS and anything -Dkey=value shaped do. Split on the first
+            # one only, or the value is truncated at it. Lines with no "=" are
+            # continuations of a multi-line value and carry no name.
+            stdout.split("\n").each do |line|
+              name, value = line.split("=", 2)
+              vars[name] = value unless value.nil?
+            end
           end
 
           vars

--- a/spec/container_helper_spec.rb
+++ b/spec/container_helper_spec.rb
@@ -110,9 +110,24 @@ describe Kitchen::Docker::Helpers::ContainerHelper do
     # rather than the first silently truncates them, and the truncated value
     # then flows into replace_env_variables and into upload paths.
     it "keeps a value containing an equals sign intact" do
-      pending "BUG: values are split on every '=' rather than the first; use split(\"=\", 2)"
       expect(with_printenv("LS_COLORS=rs=0:di=01;34\n"))
         .to eq("LS_COLORS" => "rs=0:di=01;34")
+    end
+
+    it "keeps a value that is itself a key=value list" do
+      expect(with_printenv("JAVA_OPTS=-Dfoo=bar -Dbaz=qux\n"))
+        .to eq("JAVA_OPTS" => "-Dfoo=bar -Dbaz=qux")
+    end
+
+    it "keeps a variable with an empty value" do
+      expect(with_printenv("EMPTY=\n")).to eq("EMPTY" => "")
+    end
+
+    it "ignores a continuation line of a multi-line value" do
+      # printenv prints an embedded newline literally, so the second line has no
+      # name. Recording it would put a nil-valued entry under a bogus key.
+      expect(with_printenv("CERT=-----BEGIN-----\nMIIBIjANBg\n"))
+        .to eq("CERT" => "-----BEGIN-----")
     end
 
     it "parses the JSON a Windows container returns" do


### PR DESCRIPTION
## The bug

`container_env_variables` parsed each `printenv` line like this:

```ruby
stdout.split("\n").each { |line| vars[line.split("=")[0]] = line.split("=")[1] }
```

`split("=")` splits on **every** equals sign, so any value containing one is truncated at the first.

## Reproduced against Docker 29.7.2

Read back from a real running container:

```
LS_COLORS  in container "rs=0:di=01;34"  driver read "rs"
JAVA_OPTS  in container "-Dfoo=bar"      driver read "-Dfoo"
```

## Why it matters beyond the obvious

The truncated value feeds `replace_env_variables`, which resolves environment-variable references in the paths used to stage files inside the container (`temp_dir`, and the destinations for `create_dir_on_container` / `copy_file_to_container`).

With `temp_dir: "$KITCHEN_TMP/kitchen"` and `KITCHEN_TMP=/var/tmp/a=b`, the driver resolved the path to `/var/tmp/a/kitchen` — then created that directory and uploaded to it. **Silently, in the wrong place**, with no error at any point.

That said, I want to be straight about severity: this needs an environment variable containing `=` to appear in a *path-resolving* position, which is uncommon. The truncation itself is unconditional, the fix is one line, and it removes a whole class of silent wrongness — but I would not call it urgent.

## The fix

```ruby
name, value = line.split("=", 2)
vars[name] = value unless value.nil?
```

Splitting on the first `=` only. Lines with no `=` are continuations of a multi-line value and carry no variable name, so they are skipped rather than recorded as a `nil`-valued entry under a bogus key — previously `printenv` output for a PEM-shaped variable produced junk entries.

## Verified after the change

Against a real container:

```
LS_COLORS  in container "rs=0:di=01;34"  driver read "rs=0:di=01;34"  MATCH
JAVA_OPTS  in container "-Dfoo=bar"      driver read "-Dfoo=bar"      MATCH
```

And the downstream path:

```
container KITCHEN_TMP = "/var/tmp/a=b"
temp_dir "$KITCHEN_TMP/kitchen" resolves to "/var/tmp/a=b/kitchen"
```

## Specs

The `pending` marker on this bug is removed. Added cases for a `key=value` list as a value, an empty value, and a multi-line value's continuation line.

```
$ bundle exec rake
42 files inspected, no offenses detected
260 examples, 0 failures, 9 pending
```

This branch is cut from `main`, so it still carries the pendings for the other confirmed bugs, each fixed in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
