### PR TITLE
fix: read the ssh port from the end of docker port output

### DIFF
--- a/lib/kitchen/docker/container/linux.rb
+++ b/lib/kitchen/docker/container/linux.rb
@@ -120,14 +120,27 @@ module Kitchen
 
         # Pulls the published port out of `docker port` output.
         #
-        # @param output [String] e.g. +"0.0.0.0:32768"+
+        # One line is printed per published binding, and the host part varies:
+        #
+        #   0.0.0.0:32768
+        #   [::]:32768
+        #
+        # The port is taken from the end of the line rather than by splitting on
+        # ":" from the left, because an IPv6 host contains colons of its own --
+        # splitting left-to-right returned "" for those, and "".to_i is 0, so a
+        # daemon publishing on IPv6 handed Test Kitchen port 0 to connect to.
+        #
+        # @param output [String] e.g. +"0.0.0.0:32768\n[::]:32768\n"+
         # @return [Integer] the host-side port
-        # @raise [Kitchen::ActionFailed] if the output cannot be parsed
+        # @raise [Kitchen::ActionFailed] if no port could be found
         def parse_container_ssh_port(output)
-          _host, port = output.split(":")
+          port = output.lines.filter_map { |line| line[/:(\d+)\s*\z/, 1] }.first
+
+          if port.nil?
+            raise ActionFailed, "Could not parse Docker port output for container SSH port: #{output.inspect}"
+          end
+
           port.to_i
-        rescue => e
-          raise ActionFailed, "Could not parse Docker port output for container SSH port. #{e}"
         end
 
         # The port Test Kitchen should connect to for SSH.

--- a/spec/linux_container_spec.rb
+++ b/spec/linux_container_spec.rb
@@ -54,13 +54,26 @@ describe Kitchen::Docker::Container::Linux do
     # rescue clause cannot fire. Test Kitchen is then handed port 0 and fails
     # far away from here, complaining that SSH was refused.
     it "reads the published port from an IPv6-only daemon" do
-      pending "BUG: IPv6 output parses to port 0 rather than the published port"
       expect(port(DockerOutput::PORT_IPV6_ONLY)).to eq DockerOutput::PUBLISHED_PORT
     end
 
     it "refuses to report a port it could not parse" do
-      pending "BUG: unparseable output silently yields port 0 instead of raising"
       expect { port("") }.to raise_error(Kitchen::ActionFailed)
+    end
+
+    it "reads the published port when docker names the host" do
+      expect(port("localhost:52239\n")).to eq DockerOutput::PUBLISHED_PORT
+    end
+
+    it "refuses to report a port from output with no port in it" do
+      expect { port("no public port '22/tcp' published\n") }
+        .to raise_error(Kitchen::ActionFailed, /Could not parse Docker port output/)
+    end
+
+    it "names the output it could not parse" do
+      # The previous message said only that parsing failed, which left nobody
+      # any way to tell what docker had actually printed.
+      expect { port("surprising\n") }.to raise_error(Kitchen::ActionFailed, /surprising/)
     end
 
     it "never returns a port that cannot be connected to" do


### PR DESCRIPTION
## The bug

`parse_container_ssh_port` destructured `docker port` output from the left:

```ruby
_host, port = output.split(":")
port.to_i
```

An IPv6 host contains colons of its own. For `[::1]:54115` the first two fields are `"["` and `""` — and `"".to_i` is **0**.

Worse, the method's `rescue` clause **can never fire**, because `to_i` does not raise. Any output shape it did not understand — empty, truncated, unexpected — became port 0 silently instead of an error.

## Reproduced against Docker 29.7.2

Through a real `Container::Linux` against a real daemon:

```
default publish (-p 22)
  docker port : "0.0.0.0:54114\n[::]:54114\n"
  driver reads: 54114

IPv6-bound publish (daemon.json "ip": "::1" makes -p 22 do this)
  docker port : "[::1]:54115\n"
  driver reads: 0   <-- real port is 54115
  connectable?: NO - port 0 is not a usable TCP port
```

And the dead rescue:

```
empty          -> 0  (rescue did not fire)
unparseable    -> 0  (rescue did not fire)
IPv6 only      -> 0  (rescue did not fire)
```

Test Kitchen is then handed port 0 and fails much later with a refused SSH connection, with nothing pointing back here.

**On reachability, to be straight about it:** the driver's own `-p 22` produces a dual-stack mapping on a default daemon, and that parses correctly today. Getting IPv6-only output requires the daemon's default publish address to be IPv6 (`"ip": "::1"` in `daemon.json`) — real, but not common. The part that applies to *everyone* is the second half: a function that cannot fail, and returns an unusable port instead of an error, for any output it does not recognise.

## The fix

Take the port from the **end** of the line, which is where Docker puts it regardless of whether the host is IPv4, IPv6 in brackets, or a name. Output carrying no port raises `ActionFailed` and **includes what Docker printed**, so the next person to meet an unfamiliar format can see it — the old message said only that parsing failed.

## Verified after the change

```
default publish   : "0.0.0.0:55294\n[::]:55294\n"  -> 55294
IPv6-bound publish: "[::1]:55295\n"                -> 55295   connectable: yes
empty output      -> Kitchen::ActionFailed: Could not parse Docker port output
                     for container SSH port: ""
```

And a full `kitchen create`, checking the port actually answers:

```
port: 55333
connected to port 55333: SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.18
```

## Specs

Both `pending` markers on this bug are removed. Added: a named host, output with no port raising, and the error naming the offending output.

```
$ bundle exec rake
42 files inspected, no offenses detected
260 examples, 0 failures, 8 pending
```

This branch is cut from `main`, so it still carries the pendings for the other confirmed bugs, each fixed in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
