### PR TITLE
fix: tolerate stderr warnings when parsing docker run container id (rebase of #452)

### DIFF
--- a/lib/kitchen/docker/helpers/container_helper.rb
+++ b/lib/kitchen/docker/helpers/container_helper.rb
@@ -34,19 +34,26 @@ module Kitchen
 
         # Pulls the container id out of `docker run` output.
         #
-        # Docker prints ids in short (12) or full (64) hex form; anything else
-        # means the output was not an id at all.
+        # Docker prints ids in short (12) or full (64) hex form, on a line of
+        # their own. The id is looked for line by line rather than by taking the
+        # whole output, because {CliHelper#run_command} returns stdout and stderr
+        # together and some daemons write warnings to stderr on a run that
+        # otherwise succeeds. Rootless Docker emits "WARNING: IPv4 forwarding is
+        # disabled. Networking will not work." on every run; setting
+        # +run_options+ to +--net=host+ produces "WARNING: Published ports are
+        # discarded when using host network mode", since the driver always
+        # publishes port 22 for Linux containers. Treating the whole output as
+        # the id failed those runs *after* the container had been created,
+        # leaving it running and untracked.
         #
-        # @param output [String] the command output
+        # Scanning forward is deterministic: +run_command+ concatenates stdout
+        # before stderr, so the id always precedes anything a warning adds.
+        #
+        # @param output [String] the command output, stdout and stderr together
         # @return [String] the container id
-        # @raise [Kitchen::ActionFailed] if no id could be parsed
+        # @raise [Kitchen::ActionFailed] if no id could be found
         def parse_container_id(output)
-          # Docker prints the container ID to stdout, but on some hosts (notably
-          # rootless Docker) warnings such as "WARNING: IPv4 forwarding is disabled"
-          # are emitted on stderr and can be interleaved into the captured output.
-          # Rather than assuming the whole blob is the ID, scan the lines and return
-          # the last bare 12- or 64-character hex token.
-          container_id = output.to_s.split("\n").map(&:strip).reverse.find do |line|
+          container_id = output.to_s.lines.map(&:strip).find do |line|
             line.match?(/\A[0-9a-f]{12}(?:[0-9a-f]{52})?\z/)
           end
 

--- a/lib/kitchen/docker/helpers/container_helper.rb
+++ b/lib/kitchen/docker/helpers/container_helper.rb
@@ -41,11 +41,16 @@ module Kitchen
         # @return [String] the container id
         # @raise [Kitchen::ActionFailed] if no id could be parsed
         def parse_container_id(output)
-          container_id = output.chomp
-
-          unless [12, 64].include?(container_id.size)
-            raise ActionFailed, "Could not parse Docker run output for container ID"
+          # Docker prints the container ID to stdout, but on some hosts (notably
+          # rootless Docker) warnings such as "WARNING: IPv4 forwarding is disabled"
+          # are emitted on stderr and can be interleaved into the captured output.
+          # Rather than assuming the whole blob is the ID, scan the lines and return
+          # the last bare 12- or 64-character hex token.
+          container_id = output.to_s.split("\n").map(&:strip).reverse.find do |line|
+            line.match?(/\A[0-9a-f]{12}(?:[0-9a-f]{52})?\z/)
           end
+
+          raise ActionFailed, "Could not parse Docker run output for container ID" unless container_id
 
           container_id
         end

--- a/spec/container_helper_spec.rb
+++ b/spec/container_helper_spec.rb
@@ -30,18 +30,64 @@ describe Kitchen::Docker::Helpers::ContainerHelper do
         .to raise_error(Kitchen::ActionFailed, /Could not parse Docker run output/)
     end
 
+    it "fails loudly on empty output" do
+      expect { helper.parse_container_id("") }
+        .to raise_error(Kitchen::ActionFailed, /Could not parse Docker run output/)
+    end
+
+    # Cases from #452. Rootless Docker emits this on every `docker run`, which
+    # makes it the most common way to reach this code path.
+    context "when docker wrote a warning to stderr" do
+      let(:warning) { "WARNING: IPv4 forwarding is disabled. Networking will not work." }
+
+      it "finds an id the warning follows" do
+        expect(helper.parse_container_id("#{DockerOutput::RUN_CONTAINER_ID}\n#{warning}\n"))
+          .to eq DockerOutput::RUN_CONTAINER_ID
+      end
+
+      it "finds an id the warning precedes" do
+        expect(helper.parse_container_id("#{warning}\n#{DockerOutput::RUN_CONTAINER_ID}\n"))
+          .to eq DockerOutput::RUN_CONTAINER_ID
+      end
+
+      it "finds a short id" do
+        expect(helper.parse_container_id("abcdef123456\n#{warning}\n")).to eq "abcdef123456"
+      end
+
+      it "still fails when the warning is all there is" do
+        expect { helper.parse_container_id("#{warning}\nno container id here") }
+          .to raise_error(Kitchen::ActionFailed, /Could not parse Docker run output/)
+      end
+    end
+
+    it "takes the id docker printed, not a later hex line" do
+      # run_command concatenates stdout before stderr, so the id always comes
+      # first. Scanning backwards would prefer a bare hex line that a warning
+      # happened to leave on stderr.
+      expect(helper.parse_container_id("#{DockerOutput::RUN_CONTAINER_ID}\ndeadbeefcafe\n"))
+        .to eq DockerOutput::RUN_CONTAINER_ID
+    end
+
+    it "does not mistake a hex-looking word inside a message for an id" do
+      expect { helper.parse_container_id("WARNING: layer abcdef123456 was skipped\n") }
+        .to raise_error(Kitchen::ActionFailed, /Could not parse Docker run output/)
+    end
+
+    it "tolerates surrounding whitespace on the id line" do
+      expect(helper.parse_container_id("  #{DockerOutput::RUN_CONTAINER_ID}  \n"))
+        .to eq DockerOutput::RUN_CONTAINER_ID
+    end
+
     # run_command returns stdout + stderr, and the parser requires the whole
     # combined string to be exactly the id. Anything docker writes to stderr on
     # a successful `run` therefore fails container creation, with an error that
     # blames parsing rather than naming the warning.
     it "finds the id when docker pulled the image and logged progress to stderr" do
-      pending "BUG: parse_container_id requires the entire output to be the id, so any stderr output fails the run"
       expect(helper.parse_container_id(DockerOutput::RUN_WITH_PULL_ON_STDERR))
         .to eq DockerOutput::RUN_CONTAINER_ID
     end
 
     it "finds the id when the kernel lacks swap accounting" do
-      pending "BUG: the 'No swap limit support' warning docker emits on many Linux hosts is concatenated onto the id"
       expect(helper.parse_container_id(DockerOutput::RUN_WITH_SWAP_WARNING))
         .to eq DockerOutput::RUN_CONTAINER_ID
     end


### PR DESCRIPTION
**Supersedes #452 and #472.** The fix is @jasonwbarnett's, rebased onto current `main` with authorship preserved — `git log` shows commit 1 authored by Jason Barnett.

I could not push to the branch behind #452 directly. `maintainerCanModify` reports `true`, but `altana-ai` is an **organization-owned fork**, and GitHub does not honour "allow edits by maintainers" for those — pushes are refused over both HTTPS and SSH. Hence a new branch on this repo rather than an update in place.

```
624b744  author=Tim Smith      test: relocate the container id specs and scan forward for the id
7e5e279  author=Jason Barnett  fix: tolerate stderr warnings when parsing docker run container id
```

## The bug (unchanged from #452)

`CliHelper#run_command` returns `sh.stdout + sh.stderr`, and `parse_container_id` required the entire combined string to be the id. Any warning Docker writes to stderr on an otherwise successful run therefore fails the parse — **after** the container has been created, leaving it running and untracked.

@jasonwbarnett's report identified the most common trigger: **rootless Docker** emits `WARNING: IPv4 forwarding is disabled. Networking will not work.` on every `docker run`, so rootless users hit this constantly.

## What the rebase changed

**1. Specs relocated.** #452 added its cases to `test/spec/docker_spec.rb`. Specs moved to `spec/` in #469, so that hunk conflicted. All of the original cases are kept — including the rootless-Docker warning they were written around — ported into `spec/container_helper_spec.rb` beside the rest of the `ContainerHelper` coverage.

**2. Forward scan instead of reverse.** #452 took the *last* bare hex line. `run_command` concatenates stdout before stderr, so the id always precedes anything a warning adds, which makes scanning forward deterministic and immune to a bare hex line stderr happens to leave behind:

```
                              #452           this branch
id + warning              ->  b89e1e8b0766   b89e1e8b0766
id + bare hex on stderr   ->  deadbeefcafe   b89e1e8b0766
```

A spec covers the case that separates them. Every case #452 wrote passes under both.

**3. Comments folded into YARD.** The auto-merge left the method's existing YARD docstring stale above #452's inline comment block. They are now one YARD comment recording both warnings seen in practice — rootless Docker's, and the host-network one that `run_options: --net=host` produces because the driver always publishes port 22 for Linux containers. `rake doc` stays clean at 100%.

**4. Pending markers removed** — the two examples in `spec/container_helper_spec.rb` that pinned this bug now pass.

## Verified against Docker 29.7.2

Through the driver's own `run_container`, which is what `Container::Linux#create` calls. Before:

```
RESULT: Kitchen::ActionFailed
        Could not parse Docker run output for container ID
Container was created anyway; the driver just cannot see its id:
  running containers from this image: ["d14c67e5f76a"]
```

After:

```
generated command: docker run -d -p 22 --net=host alpine:3.20 sleep 60
RESULT: succeeded, container id = a972a84bd1d242c99c80b0f4aa5852fe3017cb9483c3af4b126eaed38285307b
```

And across the output shapes:

```
rootless warning after    -> b89e1e8b0766
rootless warning before   -> b89e1e8b0766
host-network warning      -> b89e1e8b0766
swap limit warning        -> b89e1e8b0766
clean output              -> b89e1e8b0766
short id                  -> abcdef123456
no id present             -> Kitchen::ActionFailed
```

```
$ bundle exec rake
42 files inspected, no offenses detected
265 examples, 0 failures, 8 pending

$ bundle exec rake doc
no errors, no warnings, 100.00% documented
```

Remaining pendings belong to the other confirmed bugs, each in its own PR (#471, #473, #474).

🤖 Generated with [Claude Code](https://claude.com/claude-code)