### PR TITLE
fix: detect containers that exist but have stopped

### DIFF
--- a/lib/kitchen/docker/container.rb
+++ b/lib/kitchen/docker/container.rb
@@ -42,13 +42,23 @@ module Kitchen
       # container was removed behind Test Kitchen's back and silently creating a
       # new one would hide that.
       #
+      # A container that exists but has stopped is also an error, and a separate
+      # one: it is still there to be cleaned up, so the message points at
+      # `kitchen destroy` rather than claiming the container is gone.
+      #
       # @param state [Hash] mutable instance state; gains +username+
       # @return [void]
-      # @raise [Kitchen::ActionFailed] if state names a container that is gone
+      # @raise [Kitchen::ActionFailed] if state names a container that is gone,
+      #   or one that exists but is not running
       def create(state)
         if container_exists?(state)
+          unless container_running?(state)
+            raise ActionFailed, "Container ID #{state[:container_id]} was found in the kitchen state data, " \
+                                "but the container is not running. Run `kitchen destroy` to remove it."
+          end
+
           info("Container ID #{state[:container_id]} already exists.")
-        elsif !container_exists?(state) && state[:container_id]
+        elsif state[:container_id]
           raise ActionFailed, "Container ID #{state[:container_id]} was found in the kitchen state data, " \
                               "but the container does not exist."
         end

--- a/lib/kitchen/docker/helpers/container_helper.rb
+++ b/lib/kitchen/docker/helpers/container_helper.rb
@@ -93,10 +93,45 @@ module Kitchen
           config[:build_context] ? Pathname.new(file.path).relative_path_from(Pathname.pwd).to_s : file.path
         end
 
+        # Whether the container named in state is present, running or not.
+        #
+        # Asked with `docker inspect` rather than `docker top`, which answers a
+        # different question: `top` lists processes, so it fails on a container
+        # that exists but has stopped. Reading that as "does not exist" made
+        # {Kitchen::Docker::Container#destroy} skip removal and leave the
+        # container behind, while Test Kitchen deleted the state file and
+        # reported success.
+        #
         # @param state [Hash] instance state naming the container
-        # @return [Boolean] whether the container is present and running
+        # @return [Boolean] whether the container exists in any state
         def container_exists?(state)
-          state[:container_id] && !!docker_command("top #{state[:container_id]}") rescue false
+          return false unless state[:container_id]
+
+          !!docker_command("inspect --type=container #{state[:container_id]}",
+            suppress_output: !logger.debug?)
+        rescue
+          false
+        end
+
+        # Whether the container named in state is running.
+        #
+        # Separate from {#container_exists?} because the two callers want
+        # different questions answered: destroy removes a container in any
+        # state, while create has to tell a container it can use from one that
+        # has stopped.
+        #
+        # @param state [Hash] instance state naming the container
+        # @return [Boolean] whether the container exists and is running
+        def container_running?(state)
+          return false unless state[:container_id]
+
+          output = docker_command(
+            "inspect --type=container --format '{{.State.Running}}' #{state[:container_id]}",
+            suppress_output: !logger.debug?
+          )
+          output.strip == "true"
+        rescue
+          false
         end
 
         # Runs a command inside the container.

--- a/spec/container_helper_spec.rb
+++ b/spec/container_helper_spec.rb
@@ -202,6 +202,59 @@ describe Kitchen::Docker::Helpers::ContainerHelper do
     end
   end
 
+  describe "#container_exists? and #container_running?" do
+    # `docker inspect` answers for a container in any state; `docker top` only
+    # for a running one. The two predicates have to disagree on a stopped
+    # container, or destroy cannot clean it up.
+    def helper_answering(inspect_ok:, running: "false")
+      h = helper
+      allow(h).to receive(:docker_command) do |cmd, _opts = {}|
+        raise Kitchen::ShellOut::ShellCommandFailed, "No such container" unless inspect_ok
+
+        cmd.include?("{{.State.Running}}") ? "#{running}\n" : "[{...}]"
+      end
+      h
+    end
+
+    let(:state) { { container_id: "abc123abc123" } }
+
+    it "reports a running container as existing and running" do
+      h = helper_answering(inspect_ok: true, running: "true")
+      expect(h.container_exists?(state)).to be true
+      expect(h.container_running?(state)).to be true
+    end
+
+    it "reports a stopped container as existing but not running" do
+      h = helper_answering(inspect_ok: true, running: "false")
+      expect(h.container_exists?(state)).to be true
+      expect(h.container_running?(state)).to be false
+    end
+
+    it "reports a container docker does not know as neither" do
+      h = helper_answering(inspect_ok: false)
+      expect(h.container_exists?(state)).to be false
+      expect(h.container_running?(state)).to be false
+    end
+
+    it "reports no container when state names none" do
+      h = helper
+      expect(h).not_to receive(:docker_command)
+      expect(h.container_exists?({})).to be false
+      expect(h.container_running?({})).to be false
+    end
+
+    it "asks docker about a container, not about its processes" do
+      # `docker top` was the original implementation and is the bug: it fails
+      # on a stopped container, which read as the container not existing.
+      h = helper
+      seen = []
+      allow(h).to receive(:docker_command) { |cmd, _opts = {}| seen << cmd; "[{...}]" }
+      h.container_exists?(state)
+      expect(seen.join).to include("inspect --type=container")
+      expect(seen.join).not_to include("top ")
+    end
+  end
+
   describe "#remove_container" do
     it "stops the container before removing it" do
       # `docker rm` refuses to remove a running container, so the order matters.

--- a/spec/container_spec.rb
+++ b/spec/container_spec.rb
@@ -1,0 +1,115 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe Kitchen::Docker::Container do
+  subject(:container) { described_class.new(config) }
+
+  let(:config) { { username: "kitchen", remove_images: false } }
+  let(:state) { { container_id: "abc123abc123" } }
+
+  # A container that exists but has stopped is the case these two guard. It
+  # happens whenever the host reboots, the container's PID 1 exits, or someone
+  # runs `docker stop` -- so it is not an exotic state to be in.
+  def stub_container(exists:, running:)
+    allow(container).to receive(:container_exists?).and_return(exists)
+    allow(container).to receive(:container_running?).and_return(running)
+  end
+
+  describe "#destroy" do
+    it "removes a running container" do
+      stub_container(exists: true, running: true)
+      expect(container).to receive(:remove_container).with(state)
+      container.destroy(state)
+    end
+
+    it "removes a container that exists but has stopped" do
+      # Test Kitchen deletes the state file once destroy returns, so a stopped
+      # container skipped here is orphaned for good: nothing records its id any
+      # more, and `kitchen list` reports the instance as not created.
+      stub_container(exists: true, running: false)
+      expect(container).to receive(:remove_container).with(state)
+      container.destroy(state)
+    end
+
+    it "removes nothing when the container is already gone" do
+      stub_container(exists: false, running: false)
+      expect(container).not_to receive(:remove_container)
+      container.destroy(state)
+    end
+
+    context "with remove_images set" do
+      let(:config) { { username: "kitchen", remove_images: true } }
+      let(:state) { { container_id: "abc123abc123", image_id: "sha256:abc" } }
+
+      it "removes the image after the container" do
+        stub_container(exists: true, running: true)
+        allow(container).to receive(:image_exists?).and_return(true)
+        order = []
+        allow(container).to receive(:remove_container) { order << :container }
+        allow(container).to receive(:remove_image) { order << :image }
+
+        container.destroy(state)
+
+        expect(order).to eq %i{container image}
+      end
+    end
+  end
+
+  describe "#create" do
+    it "accepts a running container it has seen before" do
+      stub_container(exists: true, running: true)
+      expect { container.create(state) }.not_to raise_error
+    end
+
+    it "records the login user" do
+      stub_container(exists: true, running: true)
+      new_state = state.dup
+      container.create(new_state)
+      expect(new_state[:username]).to eq "kitchen"
+    end
+
+    it "refuses a container that exists but is not running, and says how to clear it" do
+      # Reporting this as "the container does not exist" left no way forward:
+      # the container is there, so the message has to point at destroy.
+      stub_container(exists: true, running: false)
+      expect { container.create(state) }
+        .to raise_error(Kitchen::ActionFailed, /is not running.*kitchen destroy/m)
+    end
+
+    it "refuses a container that state names but docker does not have" do
+      stub_container(exists: false, running: false)
+      expect { container.create(state) }
+        .to raise_error(Kitchen::ActionFailed, /does not exist/)
+    end
+
+    it "is happy to start from nothing" do
+      stub_container(exists: false, running: false)
+      expect { container.create({}) }.not_to raise_error
+    end
+
+    it "asks docker about the container only as often as it needs to" do
+      # The previous implementation called container_exists? twice on the path
+      # that raises, which is two `docker inspect` round trips for one answer.
+      stub_container(exists: false, running: false)
+      expect(container).to receive(:container_exists?).once.and_return(false)
+      begin
+        container.create(state)
+      rescue Kitchen::ActionFailed
+        nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## The bug

`container_exists?` asked **`docker top`**:

```ruby
def container_exists?(state)
  state[:container_id] && !!docker_command("top #{state[:container_id]}") rescue false
end
```

`docker top` lists a container's *processes*, so it fails on a container that exists but is not running:

```
running  -> docker top exit: 0
stopped  -> docker top exit: 1
but does it still exist? docker inspect exit: 0
docker ps -a shows it: afc751423cf4  Exited (137)
```

The `rescue false` then reports the container as **not existing**. Both callers act on that.

## Consequence 1 — `kitchen destroy` silently orphans the container

`Container#destroy` does `remove_container(state) if container_exists?(state)`, so removal is skipped. Test Kitchen then deletes the state file and reports success. Reproduced end to end against Docker 29.7.2:

```
1. kitchen create      -> 7a8103e283ec  Up Less than a second
2. docker stop         -> Exited (0)
3. kitchen destroy     -> Finished destroying <default-ubuntu-2404> (0m0.02s)
                          Test Kitchen is finished.
4. state file: no - kitchen believes it is destroyed
   container : 7a8103e283ec Exited (0) 1 second ago   <-- still there
   kitchen list says: <Not Created>
```

Nothing records the container's id any more. It is orphaned for good.

## Consequence 2 — `create` reports the container as missing

```
docker ps -a: 9bff00cc0d9d Exited (137)
Kitchen::ActionFailed: Container ID 9bff00cc... was found in the kitchen state
data, but the container does not exist.
```

It plainly does exist. And there was no way forward: `create` refused to build over it, `destroy` refused to remove it.

**This is not an exotic state.** A host reboot stops every container. So does the `run_command` process exiting, or `docker stop`, or restarting Docker Desktop.

## The fix

`container_exists?` now asks `docker inspect --type=container`, which answers for a container in any state — matching `image_exists?`, which already uses `inspect`.

`container_running?` is added alongside it, because the two callers want different questions answered: **destroy** removes a container whatever state it is in, **create** has to tell one it can use from one that has stopped. A container that exists but is not running now raises a message pointing at the way out:

```
Container ID 9bff00cc... was found in the kitchen state data, but the container
is not running. Run `kitchen destroy` to remove it.
```

While in there: `create` called `container_exists?` **twice** on the path that raises — two daemon round trips for one answer. It asks once now.

## Verified after the change

The same end-to-end scenario:

```
1. create          -> 1b748122ad4d  Up Less than a second
2. container stops -> Exited (0)
3. kitchen destroy -> Finished destroying <default-ubuntu-2404> (0m0.09s)
4. state file: removed
   container : gone - nothing orphaned
```

And the two failure messages are now distinct and accurate — stopped says "is not running… run `kitchen destroy`", genuinely missing still says "does not exist".

## Specs

New `spec/container_spec.rb` covers the lifecycle logic the bug lived in: destroy removes a container in either state, removes nothing when it is already gone, and removes the image after the container; create accepts a running container, refuses a stopped one with the actionable message, refuses a missing one, and starts happily from nothing.

`spec/container_helper_spec.rb` gains cases pinning that the two predicates disagree on a stopped container, and that the question is asked with `inspect` rather than `top`.

```
$ bundle exec rake
43 files inspected, no offenses detected
280 examples, 0 failures, 8 pending

$ bundle exec rake doc
clean, 100.00% documented
```

Pendings are the other confirmed bugs, each in its own PR (#471, #473, #474, #475).

🤖 Generated with [Claude Code](https://claude.com/claude-code)