### PR TITLE
fix: detect that an image is in use before removing it

### DIFF
--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -68,10 +68,28 @@ module Kitchen
           end
         end
 
+        # Whether any container was created from the image.
+        #
+        # Asked with a filter rather than by searching `docker ps -a` output for
+        # the id. That output abbreviates the IMAGE column to twelve characters,
+        # while state carries the full +sha256:+ digest, so the substring never
+        # matched and the answer was always false -- which defeated the guard
+        # entirely and let {#remove_image} run `docker rmi` against an image a
+        # container was still using.
+        #
         # @param state [Hash] instance state naming the image
         # @return [Boolean] whether any container references it
         def image_in_use?(state)
-          docker_command("ps -a", suppress_output: !logger.debug?).include?(state[:image_id])
+          return false unless state[:image_id]
+
+          output = docker_command("ps -a -q --filter ancestor=#{state[:image_id]}",
+            suppress_output: !logger.debug?)
+
+          # Matched line by line rather than by emptiness, so a warning docker
+          # writes to stderr is not mistaken for a container id.
+          output.lines.map(&:strip).any? do |line|
+            line.match?(/\A[0-9a-f]{12}(?:[0-9a-f]{52})?\z/)
+          end
         end
 
         # Builds the image from the given Dockerfile.

--- a/spec/image_helper_spec.rb
+++ b/spec/image_helper_spec.rb
@@ -122,6 +122,45 @@ describe Kitchen::Docker::Helpers::ImageHelper do
     end
   end
 
+  describe "#image_in_use?" do
+    let(:image_id) { "sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc" }
+
+    def helper_seeing(output)
+      h = helper
+      @asked = nil
+      allow(h).to receive(:docker_command) { |cmd, _opts = {}| @asked = cmd; output }
+      h
+    end
+
+    it "reports the image as in use when a container references it" do
+      expect(helper_seeing("331a7cd151e4\n").image_in_use?(image_id: image_id)).to be true
+    end
+
+    it "reports the image as free when nothing references it" do
+      expect(helper_seeing("").image_in_use?(image_id: image_id)).to be false
+    end
+
+    it "reports the image as free when state names no image" do
+      h = helper
+      expect(h).not_to receive(:docker_command)
+      expect(h.image_in_use?({})).to be false
+    end
+
+    it "asks docker to filter, rather than searching ps output for the id" do
+      # `docker ps -a` abbreviates the IMAGE column to twelve characters, so
+      # searching it for the full sha256 digest never matched and the guard
+      # was always false.
+      h = helper_seeing("331a7cd151e4\n")
+      h.image_in_use?(image_id: image_id)
+      expect(@asked).to eq "ps -a -q --filter ancestor=#{image_id}"
+    end
+
+    it "does not mistake a warning on stderr for a container" do
+      expect(helper_seeing("WARNING: something happened\n").image_in_use?(image_id: image_id))
+        .to be false
+    end
+  end
+
   describe "#remove_image" do
     let(:state) { { image_id: "sha256:abc" } }
 


### PR DESCRIPTION
## The bug

`image_in_use?` searched the *text* of `docker ps -a` for the image id:

```ruby
def image_in_use?(state)
  docker_command("ps -a", suppress_output: !logger.debug?).include?(state[:image_id])
end
```

`docker ps -a` abbreviates the IMAGE column to twelve characters, while `state[:image_id]` is the full `sha256:` digest:

```
CONTAINER ID   IMAGE
1f2b25554440   d9e853e87e55          <- what ps prints
sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc   <- what state holds
```

The substring never matched. **The guard returned false every time and never once did its job:**

```
image_in_use?(sha256:d9e853e87e555...) => false
(a container from that image IS running, so the answer should be true)
```

## What it breaks

`remove_image` ran `docker rmi` against images a container was still using. End to end with `remove_images: true`, and a second container opened from the kitchen image — what happens when someone starts one by hand to look inside:

```
$ kitchen create beta-ubuntu-2404
$ docker run -d <kitchen image> sleep 300      # poking at it in another terminal
$ kitchen destroy beta-ubuntu-2404
       [Docker] Removing image with Image ID sha256:204573659fba...
       Error response from daemon: conflict: unable to delete 204573659fba
       (cannot be forced) - image is being used by running container 3fbf69ee53c3
>>>>>> Message: 1 actions failed.

state file: present
```

`kitchen destroy` fails and the state file stays behind, so the instance is stuck half-destroyed.

**Scope, honestly:** I first assumed two kitchen suites sharing a platform would collide here. They don't — I checked, and BuildKit's attestation manifest gives every build a fresh digest even for byte-identical input, so each instance gets its own image id:

```
alpha image=sha256:19f512abb3ec
beta  image=sha256:3be4054fdeaf     # same platform, same Dockerfile, build_context either way
```

So the guard matters when something *outside* Test Kitchen holds a container from the image. That is the reproduction above, and it is the only one I could produce. The check being permanently broken is a defect regardless, but I don't want to oversell how often it bites.

## The fix

Ask Docker to do the matching:

```ruby
docker_command("ps -a -q --filter ancestor=#{state[:image_id]}", ...)
```

`--filter ancestor=` resolves the id itself and accepts the full digest — verified against a live daemon with both the full and short forms. The result is matched line by line against the shape of a container id, so a warning on stderr is not counted as a container.

## Verified after the change

```
with a container running -> image_in_use? true
after removing it        -> image_in_use? false
```

And end to end, both directions:

```
# image still in use
[Docker] Image ID sha256:2895bf735392... is in use. Skipping removal
Finished destroying <beta-ubuntu-2404> (0m0.28s).
state file: removed
image kept (correct - still in use)

# nothing using it
[Docker] Removing image with Image ID sha256:ff37350094a4...
Finished destroying <beta-ubuntu-2404> (0m0.32s).
image removed (correct - nothing using it)
```

## Specs

New cases in `spec/image_helper_spec.rb`: in use when a container references it, free when none does, free when state names no image, that a warning on stderr is not mistaken for a container, and that the question is asked with `--filter ancestor=` rather than by searching `ps` output.

```
$ bundle exec rake
43 files inspected, no offenses detected
270 examples, 0 failures, 8 pending

$ bundle exec rake doc
clean, 100.00% documented
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)