### PR TITLE
fix: read the container IP from NetworkSettings.Networks

### DIFF
--- a/lib/kitchen/docker/helpers/container_helper.rb
+++ b/lib/kitchen/docker/helpers/container_helper.rb
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 require "erb" unless defined?(Erb)
+require "ipaddr" unless defined?(IPAddr)
 require "json" unless defined?(JSON)
 require "shellwords" unless defined?(Shellwords)
 require "tempfile" unless defined?(Tempfile)
@@ -253,15 +254,47 @@ module Kitchen
           parse_container_id(output)
         end
 
+        # The container's address on the Docker network.
+        #
+        # Read from +NetworkSettings.Networks+ rather than the top-level
+        # +NetworkSettings.IPAddress+. That field was only ever populated for
+        # the default bridge, and Docker 29 removed it altogether -- asking for
+        # it there fails the whole `docker inspect` with "map has no entry for
+        # key \"IPAddress\"", which took +use_internal_docker_network+ with it.
+        # +Networks+ has been present since Docker 1.9, so reading it works on
+        # both.
+        #
+        # A container attached to several networks has an address on each; the
+        # first is used, which is the only one for the single-network case this
+        # option is for.
+        #
         # @param state [Hash] instance state naming the container
         # @return [String] the container's address on the Docker network
         # @raise [Kitchen::ActionFailed] if it cannot be determined
         def container_ip_address(state)
-          cmd = "inspect --format '{{ .NetworkSettings.IPAddress }}'"
+          cmd = "inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}'"
           cmd << " #{state[:container_id]}"
-          docker_command(cmd).strip
-        rescue
-          raise ActionFailed, "Error getting internal IP of Docker container"
+          output = docker_command(cmd, suppress_output: !logger.debug?)
+
+          # Picked by parsing rather than by taking the first word, so that a
+          # warning docker writes to stderr is not returned as an address.
+          address = output.split(/\s+/).find { |token| ip_address?(token) }
+          raise ActionFailed, "Docker reports no IP address for the container" if address.nil?
+
+          address
+        rescue => e
+          raise ActionFailed, "Error getting internal IP of Docker container. #{e}"
+        end
+
+        # @param token [String] a candidate address
+        # @return [Boolean] whether it parses as an IPv4 or IPv6 address
+        def ip_address?(token)
+          return false if token.nil? || token.empty?
+
+          IPAddr.new(token)
+          true
+        rescue IPAddr::Error
+          false
         end
 
         # Stops and removes the container.

--- a/spec/container_helper_spec.rb
+++ b/spec/container_helper_spec.rb
@@ -270,6 +270,58 @@ describe Kitchen::Docker::Helpers::ContainerHelper do
     end
   end
 
+  describe "#container_ip_address" do
+    def helper_inspecting(output)
+      h = helper
+      @asked = nil
+      allow(h).to receive(:docker_command) { |cmd, _opts = {}| @asked = cmd; output }
+      h
+    end
+
+    let(:state) { { container_id: "abc123abc123" } }
+
+    it "returns the address docker reports" do
+      expect(helper_inspecting("172.17.0.7 \n").container_ip_address(state)).to eq "172.17.0.7"
+    end
+
+    it "reads Networks rather than the removed top-level IPAddress" do
+      # Docker 29 dropped NetworkSettings.IPAddress. Asking for it does not
+      # return empty -- it fails the whole inspect with a template error, which
+      # took use_internal_docker_network down with it.
+      helper_inspecting("172.17.0.7\n").container_ip_address(state)
+      expect(@asked).to include(".NetworkSettings.Networks")
+      expect(@asked).not_to include(".NetworkSettings.IPAddress")
+    end
+
+    it "takes the first address when the container is on several networks" do
+      expect(helper_inspecting("172.17.0.7 172.19.0.2 \n").container_ip_address(state))
+        .to eq "172.17.0.7"
+    end
+
+    it "handles an IPv6 address" do
+      expect(helper_inspecting("2001:db8::2 \n").container_ip_address(state)).to eq "2001:db8::2"
+    end
+
+    it "ignores a warning docker wrote to stderr" do
+      expect(helper_inspecting("WARNING: something happened\n172.17.0.7 \n").container_ip_address(state))
+        .to eq "172.17.0.7"
+    end
+
+    it "fails loudly when docker reports no address" do
+      # Returning "" here would be recorded as the instance hostname, and the
+      # connection would fail somewhere far from the cause.
+      expect { helper_inspecting(" \n").container_ip_address(state) }
+        .to raise_error(Kitchen::ActionFailed, /no IP address/)
+    end
+
+    it "fails loudly when the inspect itself fails" do
+      h = helper
+      allow(h).to receive(:docker_command).and_raise(Kitchen::ShellOut::ShellCommandFailed, "boom")
+      expect { h.container_ip_address(state) }
+        .to raise_error(Kitchen::ActionFailed, /Error getting internal IP/)
+    end
+  end
+
   describe "#remove_container" do
     it "stops the container before removing it" do
       # `docker rm` refuses to remove a running container, so the order matters.


### PR DESCRIPTION
## The bug

`container_ip_address` asked `docker inspect` for the top-level field:

```ruby
cmd = "inspect --format '{{ .NetworkSettings.IPAddress }}'"
```

**Docker 29 removed that field.** On 29.7.2, `NetworkSettings` carries only:

```
Networks, Ports, SandboxID, SandboxKey
```

Asking for a field that is gone does not quietly return empty — Go's template engine fails the entire inspect:

```
template parsing error: template: :1:19: executing "" at
<.NetworkSettings.IPAddress>: map has no entry for key "IPAddress"
```

## What it breaks

`container_ip_address` is reached whenever `use_internal_docker_network` is set — the documented way to run this driver from inside another container. That option is therefore **broken outright on Docker 29**. Reproduced with a real `kitchen create`:

```yaml
driver:
  name: docker
  use_internal_docker_network: true
```

```
D  docker_command: docker inspect --format '{{ .NetworkSettings.IPAddress }}' 7cf7e9ef2988...
   template parsing error: ... map has no entry for key "IPAddress"
D  Message: Error getting internal IP of Docker container
>>>>>> Message: 1 actions failed.
```

It also fixes a case that was broken *before* the removal: a container on a **user-defined network** never had a top-level `IPAddress` — only a per-network one — so `run_options: --network=…` plus `use_internal_docker_network` failed on older daemons too.

## The fix

Read `NetworkSettings.Networks`, which has been present since Docker 1.9 and so works on old and new daemons alike:

```ruby
cmd = "inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}'"
```

The address is picked by **parsing** each token with `IPAddr` rather than taking the first word, so a warning on stderr is not returned as an address — a mistake this codebase has made before. Output carrying no address now raises, instead of yielding `""` to be recorded as the instance hostname and failing far from the cause.

A container on several networks has an address on each; the first is used, which is the only one in the single-network case this option exists for.

## Verified against Docker 29.7.2

```
                       driver          docker
default bridge         172.17.0.7      172.17.0.7      MATCH
user-defined network   172.19.0.2      172.19.0.2      MATCH
missing container   -> Kitchen::ActionFailed
```

And the `kitchen create` that failed above:

```
Finished creating <default-ubuntu-2404> (0m1.14s).
hostname recorded: "172.17.0.7"   port: 22
docker says its IP is: 172.17.0.7
```

## Specs

New cases in `spec/container_helper_spec.rb`: the address is returned, `Networks` is asked for and `IPAddress` is not, the first of several networks wins, IPv6 works, a stderr warning is ignored, no address raises, and a failed inspect raises.

```
$ bundle exec rake
43 files inspected, no offenses detected
280 examples, 0 failures

$ bundle exec rake doc
clean, 100.00% documented
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)