### PR TITLE
fix: remove the staged script when a command fails

### DIFF
--- a/lib/kitchen/docker/container/linux.rb
+++ b/lib/kitchen/docker/container/linux.rb
@@ -80,9 +80,6 @@ module Kitchen
           debug("Uploading temp file #{temp_file} to #{remote_path} on container")
           upload(temp_file, remote_path)
 
-          debug("Deleting temp file from local filesystem")
-          ::File.delete(temp_file)
-
           # Replace any environment variables used in the path and execute script file
           debug("Executing temp script #{remote_path}/#{filename} on container")
           remote_path = replace_env_variables(@config, remote_path)
@@ -90,6 +87,13 @@ module Kitchen
           container_exec(@config, "/bin/bash #{remote_path}/#{filename}")
         rescue => e
           raise "Failed to execute command on Linux container. #{e}"
+        ensure
+          # Removed here rather than after the upload, so that a failure part
+          # way through does not leave the script behind in .kitchen/temp.
+          if temp_file && ::File.exist?(temp_file)
+            debug("Deleting temp file from local filesystem")
+            ::File.delete(temp_file)
+          end
         end
 
         protected

--- a/lib/kitchen/docker/container/windows.rb
+++ b/lib/kitchen/docker/container/windows.rb
@@ -66,9 +66,6 @@ module Kitchen
           debug("Uploading temp file #{temp_file} to #{remote_path} on container")
           upload(temp_file, remote_path)
 
-          debug("Deleting temp file from local filesystem")
-          ::File.delete(temp_file)
-
           # Replace any environment variables used in the path and execute script file
           debug("Executing temp script #{remote_path}\\#{filename} on container")
           remote_path = replace_env_variables(@config, remote_path)
@@ -77,6 +74,13 @@ module Kitchen
           container_exec(@config, cmd)
         rescue => e
           raise "Failed to execute command on Windows container. #{e}"
+        ensure
+          # Removed here rather than after the upload, so that a failure part
+          # way through does not leave the script behind in .kitchen/temp.
+          if temp_file && ::File.exist?(temp_file)
+            debug("Deleting temp file from local filesystem")
+            ::File.delete(temp_file)
+          end
         end
 
         protected

--- a/spec/linux_container_spec.rb
+++ b/spec/linux_container_spec.rb
@@ -168,6 +168,51 @@ describe Kitchen::Docker::Container::Linux do
     end
   end
 
+  describe "#execute" do
+    # The command is staged as a script under .kitchen/temp and uploaded. That
+    # local copy has to go whether or not the rest of the run works, or a failing
+    # converge leaves a file behind on every attempt.
+    def container_in(dir, &upload)
+      c = container
+      allow(c).to receive(:create_dir_on_container)
+      allow(c).to receive(:replace_env_variables) { |_cfg, path| path }
+      allow(c).to receive(:container_exec).and_return("ok")
+      allow(c).to receive(:upload, &(upload || ->(*) { nil }))
+      allow(Dir).to receive(:pwd).and_return(dir)
+      c
+    end
+
+    around do |example|
+      Dir.chdir(@tmpdir) { example.run }
+    end
+
+    it "removes the staged script once the command has run" do
+      c = container_in(@tmpdir)
+      c.execute("echo hi")
+      expect(Dir.glob(".kitchen/temp/docker-*.sh")).to be_empty
+    end
+
+    it "removes the staged script when the upload fails" do
+      c = container_in(@tmpdir) { raise "upload exploded" }
+      expect { c.execute("echo hi") }.to raise_error(/Failed to execute command/)
+      expect(Dir.glob(".kitchen/temp/docker-*.sh")).to be_empty
+    end
+
+    it "removes the staged script when the command itself fails" do
+      c = container_in(@tmpdir)
+      allow(c).to receive(:container_exec).and_raise("command exploded")
+      expect { c.execute("echo hi") }.to raise_error(/Failed to execute command/)
+      expect(Dir.glob(".kitchen/temp/docker-*.sh")).to be_empty
+    end
+
+    it "uploads the command as the contents of the script" do
+      uploaded = nil
+      c = container_in(@tmpdir) { |local, _remote| uploaded = ::File.read(local) }
+      c.execute("echo hi")
+      expect(uploaded).to eq "echo hi"
+    end
+  end
+
   describe "#generate_keys" do
     it "writes a usable key pair when none exists" do
       private_key = File.join(@tmpdir, "generated")


### PR DESCRIPTION
## The bug

`Container#execute` stages the command as a script under `.kitchen/temp`, uploads it to the container, and deletes the local copy. The delete sat **between** the upload and the exec:

```ruby
create_temp_file(temp_file, command)
create_dir_on_container(@config, remote_path)
upload(temp_file, remote_path)

::File.delete(temp_file)        # <- skipped if anything above raises

container_exec(@config, "/bin/bash #{remote_path}/#{filename}")
rescue => e
  raise "Failed to execute command on Linux container. #{e}"
```

Any failure before that line leaves the script behind.

## Confirmed

Removing the container out from under a `kitchen exec` — which is what a container that has exited looks like to the driver:

```
after a successful exec : 0 file(s) left
after a failing exec    : 1 file(s) left
   docker-cbdc94fe-ee7e-45d9-b293-d1f895773a2b.sh
```

One file per failed attempt, and nothing ever clears them, so `.kitchen/temp` fills up over a run of failing converges. Minor, but it is a leak the code plainly intends not to have.

## The fix

Delete in an `ensure`, in both the Linux and Windows containers — they share the shape of this method and both had it.

## Deliberately not addressed

The uploaded copy **inside** the container is never removed either — three execs leave three scripts in the container's temp directory:

```
scripts left in the container's /tmp: 3
```

Those go when the container does, and removing them would add a `docker exec` round trip per command for no real benefit. Flagging it rather than changing it; happy to if you'd rather.

## Verified after the change

```
after a successful exec : 0 file(s) left
after a failing exec    : 0 file(s) left
```

## Specs

New `#execute` group in `spec/linux_container_spec.rb`: the staged script is removed after a successful run, after a failed upload, and after a failed command — plus one pinning that the command really is what gets written to the script.

```
$ bundle exec rake
43 files inspected, no offenses detected
277 examples, 0 failures

$ bundle exec rake doc
clean, 100.00% documented
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)