### PR TITLE
fix: stop printing the image inspect JSON on destroy

### DIFF
--- a/lib/kitchen/docker/helpers/image_helper.rb
+++ b/lib/kitchen/docker/helpers/image_helper.rb
@@ -126,10 +126,28 @@ module Kitchen
           parse_image_id(output)
         end
 
+        # Whether the image named in state is present locally.
+        #
+        # The inspect is silenced, as every other predicate that shells out to
+        # docker is. Left speaking, `kitchen destroy` on an instance with
+        # +remove_images+ set printed the image's entire `docker inspect` JSON
+        # -- config, every layer digest, metadata -- into the middle of the
+        # destroy output, between the container being removed and the image
+        # being removed. Nothing read it: only whether the command succeeded is
+        # used.
+        #
+        # It is still printed under `-l debug`, where the rest of the driver's
+        # docker traffic is.
+        #
         # @param state [Hash] instance state naming the image
         # @return [Boolean] whether the image is present locally
         def image_exists?(state)
-          state[:image_id] && !!docker_command("inspect --type=image #{state[:image_id]}") rescue false
+          return false unless state[:image_id]
+
+          !!docker_command("inspect --type=image #{state[:image_id]}",
+            suppress_output: !logger.debug?)
+        rescue
+          false
         end
       end
     end

--- a/spec/image_helper_spec.rb
+++ b/spec/image_helper_spec.rb
@@ -178,4 +178,49 @@ describe Kitchen::Docker::Helpers::ImageHelper do
       h.remove_image(state)
     end
   end
+
+  describe "#image_exists?" do
+    let(:state) { { image_id: "sha256:abc" } }
+
+    def asking(&answer)
+      helper.tap do |h|
+        @opts = nil
+        allow(h).to receive(:logger).and_return(double(debug?: false, debug: nil))
+        allow(h).to receive(:docker_command) { |_cmd, opts = {}| @opts = opts; answer.call }
+      end
+    end
+
+    it "is true when docker knows the image" do
+      expect(asking { "[{}]" }.image_exists?(state)).to be true
+    end
+
+    it "is false when docker does not" do
+      expect(asking { raise Kitchen::ShellOut::ShellCommandFailed, "no such image" }
+        .image_exists?(state)).to be false
+    end
+
+    it "does not ask about an image that state does not name" do
+      h = helper
+      expect(h).not_to receive(:docker_command)
+      expect(h.image_exists?({})).to be false
+    end
+
+    # `kitchen destroy` with remove_images set printed the image's whole
+    # inspect JSON -- config, every layer digest, metadata -- between removing
+    # the container and removing the image. Only whether the command succeeded
+    # is used here, as in every other predicate in this file, all of which
+    # already silence their output.
+    it "does not print the inspect output" do
+      asking { "[{}]" }.image_exists?(state)
+      expect(@opts).to eq(suppress_output: true)
+    end
+
+    it "still prints it under -l debug" do
+      h = helper
+      allow(h).to receive(:logger).and_return(double(debug?: true, debug: nil))
+      allow(h).to receive(:docker_command) { |_cmd, opts = {}| @opts = opts; "[{}]" }
+      h.image_exists?(state)
+      expect(@opts).to eq(suppress_output: false)
+    end
+  end
 end


### PR DESCRIPTION
`image_exists?` is the only predicate in the driver that shells out to docker without silencing it. Its three siblings -- `container_exists?`, `container_running?`, and `image_in_use?` -- all pass `suppress_output`.

So `kitchen destroy` on an instance with `remove_images: true` prints the image's entire `docker inspect` output -- config, environment, every layer digest, metadata, descriptor; about sixty lines of JSON -- in the middle of the destroy output, between the container being removed and the image being removed.

Nothing reads it. Only whether the command succeeded is used.

## Before

```
-----> Destroying <default-ubuntu-2404>...
       [Docker] Destroying Docker container 282c247814fc40dc81b689df0168ec83ee536257f8004ed116257b401688b58d
       282c247814fc40dc81b689df0168ec83ee536257f8004ed116257b401688b58d
       282c247814fc40dc81b689df0168ec83ee536257f8004ed116257b401688b58d
       [
           {
        "Id": "sha256:33c8e9c76cc4d4c1342411aded4f03c30fc69b964074505a1c0f3433c07b84a7",
        "RepoTags": [],
        "RepoDigests": [],
        "Comment": "buildkit.dockerfile.v0",
        "Created": "2026-08-23T16:32:50.994001424Z",
        "Config": { ... },
        "RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:646eea22414270d74b0c9e9d6d3b9550701ae62e658a099825d4d15045a3630b",
                ... 16 more ...
            ]
        },
        ...
           }
       ]
       [Docker] Removing image with Image ID sha256:33c8e9c76cc4...
       Deleted: sha256:33c8e9c76cc4...
       Finished destroying <default-ubuntu-2404> (0m0.29s).
```

## After

```
-----> Destroying <default-ubuntu-2404>...
       [Docker] Destroying Docker container a2ad8e06fe96b8b7515b87f330e8677f5712adb896418fe53cdcda1ab5cfd496
       a2ad8e06fe96b8b7515b87f330e8677f5712adb896418fe53cdcda1ab5cfd496
       a2ad8e06fe96b8b7515b87f330e8677f5712adb896418fe53cdcda1ab5cfd496
       [Docker] Removing image with Image ID sha256:a659812d1948c2baaede157ea045cd61bae082cc48964bc82605b0062d895197.
       Deleted: sha256:a659812d1948c2baaede157ea045cd61bae082cc48964bc82605b0062d895197
       Finished destroying <default-ubuntu-2404> (0m0.31s).
```

Still printed under `-l debug`, where the rest of the driver's docker traffic goes -- confirmed in the same run.

The bare ids `docker stop` and `docker rm` echo are deliberately left alone: unlike this, they are what those commands report, not a predicate's incidental output.

The method also picked up an early return for the no-image case, so the guard reads the same way as `container_exists?` and `image_in_use?` rather than relying on a modifier `rescue` spanning an `&&`.

## Confirmation

Docker 29.7.2 (Docker Desktop 4.87.0, macOS/arm64), Test Kitchen 4.1.1. Output above is from real `kitchen create` / `kitchen destroy` runs against an `ubuntu-24.04` container with `remove_images: true`.

`rake style` clean; `rspec` 318 examples, 0 failures (5 new).
