### PR TITLE
fix: report this gem's own version to kitchen diagnose

### DIFF
--- a/lib/kitchen/driver/docker.rb
+++ b/lib/kitchen/driver/docker.rb
@@ -23,6 +23,7 @@ require "kitchen/driver/base"
 
 require_relative "../docker/container/linux"
 require_relative "../docker/container/windows"
+require_relative "../docker/docker_version"
 require_relative "../docker/helpers/cli_helper"
 require_relative "../docker/helpers/container_helper"
 
@@ -36,6 +37,13 @@ module Kitchen
       include Kitchen::Docker::Helpers::CliHelper
       include Kitchen::Docker::Helpers::ContainerHelper
       include ShellOut
+
+      # Reported by `kitchen diagnose`, which is what a bug report is asked to
+      # include. The version is this gem's own: the transport used to report
+      # Kitchen::VERSION, which is Test Kitchen's, so a diagnose said the
+      # plugin was at whatever version Test Kitchen happened to be.
+      kitchen_driver_api_version 2
+      plugin_version Kitchen::Docker::DOCKER_VERSION
 
       default_config :binary,        "docker"
       default_config :build_options, nil

--- a/lib/kitchen/transport/docker.rb
+++ b/lib/kitchen/transport/docker.rb
@@ -15,6 +15,7 @@ require "kitchen"
 
 require_relative "../docker/container/linux"
 require_relative "../docker/container/windows"
+require_relative "../docker/docker_version"
 
 require_relative "../docker/helpers/inspec_helper"
 
@@ -31,8 +32,11 @@ module Kitchen
       # Raised when a docker command against the container fails.
       class DockerFailed < TransportFailed; end
 
-      # kitchen_transport_api_version 1
-      plugin_version Kitchen::VERSION
+      # Reported by `kitchen diagnose`. plugin_version was Kitchen::VERSION,
+      # which is Test Kitchen's version rather than this gem's, so a diagnose
+      # reported the transport as 4.1.1 while kitchen-docker was at 3.3.4.
+      kitchen_transport_api_version 1
+      plugin_version Kitchen::Docker::DOCKER_VERSION
 
       default_config :binary,        "docker"
       default_config :env_variables, nil

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -17,6 +17,24 @@
 require "spec_helper"
 
 describe Kitchen::Driver::Docker do
+  # `kitchen diagnose` is what bug reports are asked to include, so what it
+  # says about the plugin has to be true. The transport reported
+  # Kitchen::VERSION, which is Test Kitchen's version, and the driver reported
+  # nothing at all.
+  describe "plugin metadata" do
+    it "reports this gem's version, not Test Kitchen's" do
+      expect(described_class.diagnose[:version]).to eq Kitchen::Docker::DOCKER_VERSION
+    end
+
+    it "does not report Test Kitchen's version" do
+      expect(described_class.diagnose[:version]).not_to eq Kitchen::VERSION
+    end
+
+    it "declares the driver API version it is written against" do
+      expect(described_class.diagnose[:api_version]).to eq 2
+    end
+  end
+
   describe "#config_to_options" do
     let(:config) {}
     subject { described_class.new.send(:config_to_options, config) }

--- a/spec/transport_docker_spec.rb
+++ b/spec/transport_docker_spec.rb
@@ -15,6 +15,26 @@
 require "spec_helper"
 require "kitchen/transport/docker"
 
+describe Kitchen::Transport::Docker do
+  # `kitchen diagnose` is what bug reports are asked to include, so what it
+  # says about the plugin has to be true.
+  describe "plugin metadata" do
+    it "reports this gem's version, not Test Kitchen's" do
+      expect(described_class.diagnose[:version]).to eq Kitchen::Docker::DOCKER_VERSION
+    end
+
+    it "does not report Test Kitchen's version" do
+      # It did: `plugin_version Kitchen::VERSION` made a diagnose say the
+      # transport was at Test Kitchen's version rather than this gem's.
+      expect(described_class.diagnose[:version]).not_to eq Kitchen::VERSION
+    end
+
+    it "declares the transport API version it is written against" do
+      expect(described_class.diagnose[:api_version]).to eq 1
+    end
+  end
+end
+
 describe Kitchen::Transport::Docker::Connection do
   let(:options) do
     {


### PR DESCRIPTION
`kitchen diagnose` is what bug reports are asked to include, and what it said about this plugin was wrong in both halves.

## Before

```yaml
driver:
  Docker:
    class: Kitchen::Driver::Docker
    version:            # nothing
    api_version:        # nothing
transport:
  Docker:
    class: Kitchen::Transport::Docker
    version: 4.1.1      # Test Kitchen's version, not kitchen-docker's
    api_version:
```

The transport declared `plugin_version Kitchen::VERSION` — that constant is *Test Kitchen's* version, so a diagnose from kitchen-docker 3.3.4 running under Test Kitchen 4.1.1 reported the transport as 4.1.1. The driver declared no version at all, and `kitchen_transport_api_version` was sitting there commented out.

Every plugin shipped with Test Kitchen declares both (`kitchen_driver_api_version 2`, `kitchen_transport_api_version 1`).

## After

```yaml
driver:
  Docker:
    class: Kitchen::Driver::Docker
    version: 3.3.4
    api_version: 2
transport:
  Docker:
    class: Kitchen::Transport::Docker
    version: 3.3.4
    api_version: 1
```

## Risk

None to behaviour. Both values are diagnostic only — nothing in Test Kitchen branches on either; `api_version` is read exactly once, by `Configurable.diagnose`. This changes what is reported and nothing else.

## Confirmation

Output above is real `kitchen diagnose --all` against Test Kitchen 4.1.1, before and after.

`rake style` clean; `rspec` 319 examples, 0 failures (6 new, including one pinning that the reported version is not `Kitchen::VERSION`).
