### PR TITLE
fix: require test-kitchen 3.0 or newer

### DIFF
--- a/kitchen-docker.gemspec
+++ b/kitchen-docker.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($/)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "test-kitchen", ">= 1.0.0", "< 5.0"
+  spec.add_dependency "test-kitchen", ">= 3.0", "< 5.0"
 end


### PR DESCRIPTION
The dependency floor was `>= 1.0.0`:

```ruby
spec.add_dependency "test-kitchen", ">= 1.0.0", "< 5.0"
```

That has not been true for a long time. The gem already declares `required_ruby_version >= 3.1`, Test Kitchen 1.x and 2.x are both end of life, and CI has never run against anything below 4. Bundler was free to resolve a pairing nobody has ever run.

```ruby
spec.add_dependency "test-kitchen", ">= 3.0", "< 5.0"
```

The `< 5.0` ceiling is unchanged.

`rake style` clean; `rspec` 313 examples, 0 failures; `bundle check` satisfied.

---

**One thing worth knowing before this merges.** I tested the gem against real Test Kitchen 1.25.0 / 2.12.0 / 3.0.0 / 3.9.1 bundles, and **it does not currently work on Test Kitchen 3 at all**:

```text
$ kitchen create          # test-kitchen 3.9.1, real ubuntu-24.04
-----> Creating <default-ubuntu-2404>...
>>>>>> Failed to complete #create action:
       [undefined method 'to_blob' for an instance of OpenSSL::PKey::RSA]
```

`generate_keys` calls `OpenSSL::PKey::RSA#to_blob`, which net-ssh adds by reopening the class. The driver requires net-ssh as `require "net/ssh" unless defined?(Net::SSH)` — but Test Kitchen 3's `kitchen/ssh.rb` contains:

```ruby
module Net
  autoload :SSH, "net/ssh"
end
```

An autoload defines the constant immediately as a placeholder, so `defined?(Net::SSH)` is truthy before net-ssh has loaded a line. The guard skips the require, the monkey patch is never applied, and every Linux `kitchen create` dies. Test Kitchen 4 dropped `kitchen/ssh.rb`, which is the only reason this is invisible today.

That is a separate one-line fix (drop the guard — the require is for a side effect, not a constant), so I have left it out of this PR. Happy to open it next; this floor bump is still strictly an improvement on `>= 1.0.0` either way.
