### PR TITLE
test: cover the driver, transport, and container logic that had none

### DIFF
--- a/spec/container_spec.rb
+++ b/spec/container_spec.rb
@@ -112,4 +112,53 @@ describe Kitchen::Docker::Container do
       end
     end
   end
+  # Where Test Kitchen is told to connect. All three cases produce something
+  # that looks like a host, so getting it wrong does not fail here -- it fails
+  # later, as a connection timeout against an address nothing is listening on.
+  describe "#hostname" do
+    it "is localhost for a local daemon, where the port is published" do
+      expect(described_class.new(socket: "unix:///var/run/docker.sock").hostname(state))
+        .to eq "localhost"
+    end
+
+    # The published port is on the machine running the daemon, not on this one.
+    it "is the daemon's host when the socket is remote" do
+      expect(described_class.new(socket: "tcp://docker.example.com:2376").hostname(state))
+        .to eq "docker.example.com"
+    end
+
+    it "is the container's own address on the internal network" do
+      c = described_class.new(socket: "unix:///var/run/docker.sock", use_internal_docker_network: true)
+      allow(c).to receive(:container_ip_address).with(state).and_return("172.17.0.2")
+      expect(c.hostname(state)).to eq "172.17.0.2"
+    end
+
+    # A remote daemon has no route back to a container address, so the socket
+    # host has to win over the internal network.
+    it "prefers the daemon's host over the internal network" do
+      c = described_class.new(socket: "tcp://docker.example.com:2376", use_internal_docker_network: true)
+      expect(c).not_to receive(:container_ip_address)
+      expect(c.hostname(state)).to eq "docker.example.com"
+    end
+  end
+
+  describe "#upload" do
+    it "copies a single file" do
+      expect(container).to receive(:copy_file_to_container).with(config, "/local/f.rb", "/tmp")
+      container.upload("/local/f.rb", "/tmp")
+    end
+
+    it "copies every file it is given" do
+      copied = []
+      allow(container).to receive(:copy_file_to_container) { |_cfg, file, _remote| copied << file }
+      container.upload(["/local/a.rb", "/local/b.rb"], "/tmp")
+      expect(copied).to eq ["/local/a.rb", "/local/b.rb"]
+    end
+
+    it "returns the files it copied" do
+      allow(container).to receive(:copy_file_to_container)
+      expect(container.upload(["/local/a.rb"], "/tmp")).to eq ["/local/a.rb"]
+    end
+  end
+
 end

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -233,47 +233,252 @@ describe Kitchen::Driver::Docker do
     end
   end
 
-  describe "socket default config logic" do
-    def resolve_socket
-      socket = "unix:///var/run/docker.sock"
-      socket = "npipe:////./pipe/docker_engine" if Gem.win_platform?
-      ENV["DOCKER_HOST"] || socket
+  # The lazy `default_config` blocks are where most of "it just works with a
+  # platform name and nothing else" lives. They were previously exercised by a
+  # spec that re-implemented the socket block and asserted on its own copy,
+  # which would have passed with the driver's block deleted. These read the
+  # values back off a driver, which is what Test Kitchen does.
+  describe "default configuration" do
+    def configured(config = {}, platform: "ubuntu-24.04")
+      described_class.new(config).tap do |d|
+        allow(d).to receive(:instance).and_return(
+          instance_double("Kitchen::Instance",
+            name: "default-#{platform.delete(".")}",
+            platform: Kitchen::Platform.new(name: platform))
+        )
+      end
     end
 
-    context "on a non-Windows host without DOCKER_HOST set" do
-      before do
+    describe ":socket" do
+      around do |example|
+        saved = ENV["DOCKER_HOST"]
+        example.run
+        saved.nil? ? ENV.delete("DOCKER_HOST") : ENV["DOCKER_HOST"] = saved
+      end
+
+      it "defaults to the Unix socket" do
+        ENV.delete("DOCKER_HOST")
         allow(Gem).to receive(:win_platform?).and_return(false)
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("DOCKER_HOST").and_return(nil)
+        expect(configured[:socket]).to eq "unix:///var/run/docker.sock"
       end
 
-      it "uses the Unix socket" do
-        expect(resolve_socket).to eq("unix:///var/run/docker.sock")
-      end
-    end
-
-    context "on a Windows host without DOCKER_HOST set" do
-      before do
+      it "defaults to the named pipe on a Windows host" do
+        ENV.delete("DOCKER_HOST")
         allow(Gem).to receive(:win_platform?).and_return(true)
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("DOCKER_HOST").and_return(nil)
+        expect(configured[:socket]).to eq "npipe:////./pipe/docker_engine"
       end
 
-      it "uses the Windows named pipe" do
-        expect(resolve_socket).to eq("npipe:////./pipe/docker_engine")
+      # Read lazily rather than at require time, so that a DOCKER_HOST exported
+      # after the plugin was loaded -- which is what a shell wrapper or a
+      # Rakefile does -- is still honoured.
+      it "prefers DOCKER_HOST" do
+        ENV["DOCKER_HOST"] = "tcp://192.168.1.1:2375"
+        expect(configured[:socket]).to eq "tcp://192.168.1.1:2375"
       end
     end
 
-    context "when DOCKER_HOST env var is set" do
-      before do
-        allow(Gem).to receive(:win_platform?).and_return(false)
-        allow(ENV).to receive(:[]).and_call_original
-        allow(ENV).to receive(:[]).with("DOCKER_HOST").and_return("tcp://192.168.1.1:2375")
+    describe ":image and :platform" do
+      it "derives both from the platform name" do
+        d = configured({}, platform: "ubuntu-24.04")
+        expect(d[:image]).to eq "ubuntu:24.04"
+        expect(d[:platform]).to eq "ubuntu"
       end
 
-      it "uses DOCKER_HOST over the default socket" do
-        expect(resolve_socket).to eq("tcp://192.168.1.1:2375")
+      it "leaves a name with no release as a bare image" do
+        expect(configured({}, platform: "fedora")[:image]).to eq "fedora"
       end
+
+      # CentOS images are tagged `centos7`, not `7`, so the release needs the
+      # distribution name in front of it.
+      it "special-cases centos, whose tags carry the distribution name" do
+        expect(configured({}, platform: "centos-7")[:image]).to eq "centos:centos7"
+      end
+
+      it "drops the point release from a centos tag" do
+        expect(configured({}, platform: "centos-6.5")[:image]).to eq "centos:centos6"
+      end
+
+      # Documented rather than endorsed: the family is the first segment, so a
+      # platform named for a variant needs `platform` set explicitly. Both of
+      # these are examples the README tells you to configure by hand.
+      it "reads only the first segment as the family" do
+        expect(configured({}, platform: "centos-stream-9")[:platform]).to eq "centos"
+        expect(configured({}, platform: "gentoo-paludis")[:platform]).to eq "gentoo"
+      end
+
+      it "yields to a configured image" do
+        expect(configured({ image: "dokken/centos-stream-9" })[:image]).to eq "dokken/centos-stream-9"
+      end
+    end
+
+    describe ":username" do
+      it "is the account the generated Dockerfile creates" do
+        expect(configured[:username]).to eq "kitchen"
+      end
+
+      # A Windows image has no account to create, and passing `-u` with a name
+      # that does not exist there fails every exec.
+      it "is unset on Windows, where none is created" do
+        expect(configured({}, platform: "windows-2022")[:username]).to be_nil
+      end
+    end
+
+    describe ":run_command" do
+      it "runs sshd in the foreground on Linux" do
+        expect(configured[:run_command]).to start_with "/usr/sbin/sshd -D"
+      end
+
+      # Windows containers are driven through `docker exec`, so PID 1 only has
+      # to stay alive.
+      it "keeps a Windows container alive with a long-running ping" do
+        expect(configured({}, platform: "windows-2022")[:run_command]).to eq "ping -t localhost"
+      end
+
+      it "runs PowerShell on an interactive Windows container" do
+        expect(configured({ interactive: true }, platform: "windows-2022")[:run_command])
+          .to eq "powershell.exe"
+      end
+    end
+
+    describe ":build_context" do
+      it "sends the working directory to a local daemon" do
+        expect(configured({ socket: "unix:///var/run/docker.sock" })[:build_context]).to be true
+      end
+
+      # Sending the whole working directory over the network is slow enough to
+      # be worth defaulting off.
+      it "does not send it to a remote daemon" do
+        expect(configured({ socket: "tcp://docker.example.com:2376" })[:build_context]).to be false
+      end
+    end
+
+    describe ":instance_name" do
+      it "starts with the instance it belongs to" do
+        expect(configured[:instance_name]).to start_with "defaultubuntu2404-"
+      end
+
+      it "is a name Docker accepts" do
+        expect(configured[:instance_name]).to match(/\A[a-z0-9][a-z0-9_.-]*\z/)
+      end
+
+      # Two instances of the same suite must not collide, which is what lets
+      # `kitchen test -c` run them at once.
+      it "differs between drivers" do
+        expect(configured[:instance_name]).not_to eq configured[:instance_name]
+      end
+    end
+
+    describe ":package_name" do
+      it "names the image after the instance" do
+        expect(configured[:package_name]).to eq "default-ubuntu-2404:latest"
+      end
+
+      it "is a valid Docker repository name even when the instance name is not" do
+        d = described_class.new
+        allow(d).to receive(:instance).and_return(
+          instance_double("Kitchen::Instance", name: "Default-Ubuntu_24.04")
+        )
+        expect(d[:package_name]).to eq "default-ubuntu_24.04:latest"
+      end
+    end
+  end
+
+  describe "#container" do
+    it "builds a Linux container for a Linux platform" do
+      expect(driver_for_platform("ubuntu-24.04").send(:container))
+        .to be_a Kitchen::Docker::Container::Linux
+    end
+
+    # The two classes generate completely different Dockerfiles and reach the
+    # container in completely different ways, so picking the wrong one produces
+    # an image that cannot be built rather than a subtly wrong one.
+    it "builds a Windows container for a Windows platform" do
+      expect(driver_for_platform("windows-2022").send(:container))
+        .to be_a Kitchen::Docker::Container::Windows
+    end
+
+    it "reuses the same container across calls" do
+      d = driver_for_platform("ubuntu-24.04")
+      expect(d.send(:container)).to be d.send(:container)
+    end
+
+    def driver_for_platform(name)
+      described_class.new.tap do |d|
+        allow(d).to receive(:instance).and_return(
+          instance_double("Kitchen::Instance", name: "default", platform: Kitchen::Platform.new(name: name))
+        )
+      end
+    end
+  end
+
+  describe "#destroy" do
+    it "hands the container off to be removed" do
+      d = driver
+      c = instance_double(Kitchen::Docker::Container::Linux)
+      allow(d).to receive(:container).and_return(c)
+      state = { container_id: "abc123abc123" }
+      expect(c).to receive(:destroy).with(state)
+      d.destroy(state)
+    end
+  end
+
+  describe "#create" do
+    it "creates the container and then waits for the transport" do
+      d = driver
+      c = instance_double(Kitchen::Docker::Container::Linux)
+      allow(d).to receive(:container).and_return(c)
+      state = {}
+
+      expect(c).to receive(:create).with(state).ordered
+      expect(d).to receive(:wait_for_transport).with(state).ordered
+
+      d.create(state)
+    end
+  end
+
+  describe "#wait_for_transport" do
+    def driver_waiting(wait)
+      d = driver({ wait_for_transport: wait })
+      @connection = double("connection")
+      transport = double("transport")
+      allow(transport).to receive(:connection) { |_state, &blk| blk.call(@connection) }
+      allow(d.instance).to receive(:transport).and_return(transport)
+      d
+    end
+
+    it "waits for the transport to answer before converging" do
+      d = driver_waiting(true)
+      expect(@connection).to receive(:wait_until_ready)
+      d.wait_for_transport({})
+    end
+
+    # For a container that is not meant to stay up, waiting is a guaranteed
+    # timeout rather than a safety net.
+    it "does not wait when told not to" do
+      d = driver_waiting(false)
+      expect(@connection).not_to receive(:wait_until_ready)
+      d.wait_for_transport({})
+    end
+  end
+
+  describe "#verify_dependencies" do
+    it "says how to install Docker when the CLI is not there" do
+      d = driver
+      allow(d).to receive(:run_command).and_raise(Kitchen::ShellOut::ShellCommandFailed, "not found")
+      expect { d.verify_dependencies }
+        .to raise_error(Kitchen::UserError, /must first install the Docker CLI/)
+    end
+
+    it "says nothing when the CLI runs" do
+      d = driver
+      allow(d).to receive(:run_command).and_return("")
+      expect { d.verify_dependencies }.not_to raise_error
+    end
+
+    it "probes through sudo when configured to" do
+      d = driver({ use_sudo: true })
+      expect(d).to receive(:run_command).with(anything, hash_including(use_sudo: true))
+      d.verify_dependencies
     end
   end
 end

--- a/spec/linux_container_spec.rb
+++ b/spec/linux_container_spec.rb
@@ -35,6 +35,58 @@ describe Kitchen::Docker::Container::Linux do
     }.merge(config))
   end
 
+  # The state this populates is the whole contract with the rest of Test
+  # Kitchen: the transport and the verifier read these keys, and a missing one
+  # surfaces as a nil far from here.
+  describe "#create" do
+    def creating(config = {})
+      c = container(config)
+      allow(c).to receive(:container_exists?).and_return(false)
+      allow(c).to receive(:build_image).and_return("sha256:abc")
+      allow(c).to receive(:run_container).and_return("abc123abc123")
+      allow(c).to receive(:hostname).and_return("localhost")
+      allow(c).to receive(:docker_command).and_return("0.0.0.0:32768\n")
+      c
+    end
+
+    it "records everything the transport needs to connect" do
+      state = {}
+      creating.create(state)
+      expect(state).to include(
+        image_id: "sha256:abc",
+        container_id: "abc123abc123",
+        hostname: "localhost",
+        username: "kitchen",
+        port: 32768
+      )
+    end
+
+    it "records the key it generated, so SSH can use it" do
+      state = {}
+      creating.create(state)
+      expect(state[:ssh_key]).to eq File.join(@tmpdir, "docker_id_rsa")
+    end
+
+    # 22 is the port inside the container; Docker publishes it on an arbitrary
+    # host port, which is the one to connect to.
+    it "publishes the SSH port" do
+      c = creating
+      expect(c).to receive(:run_container).with(anything, 22).and_return("abc123abc123")
+      c.create({})
+    end
+
+    # Re-running create against an instance that is already up must not build a
+    # second image or start a second container.
+    it "reuses an image and container the state already names" do
+      c = creating
+      allow(c).to receive(:container_exists?).and_return(true)
+      allow(c).to receive(:container_running?).and_return(true)
+      expect(c).not_to receive(:build_image)
+      expect(c).not_to receive(:run_container)
+      c.create(image_id: "sha256:old", container_id: "old123old123")
+    end
+  end
+
   describe "#parse_container_ssh_port" do
     def port(output)
       container.send(:parse_container_ssh_port, output)

--- a/spec/transport_docker_spec.rb
+++ b/spec/transport_docker_spec.rb
@@ -33,6 +33,96 @@ describe Kitchen::Transport::Docker do
       expect(described_class.diagnose[:api_version]).to eq 1
     end
   end
+
+  def transport(config = {}, platform: "ubuntu-24.04")
+    described_class.new(config).tap do |t|
+      allow(t).to receive(:instance).and_return(
+        instance_double("Kitchen::Instance",
+          name: "default", platform: Kitchen::Platform.new(name: platform))
+      )
+    end
+  end
+
+  describe "default configuration" do
+    describe ":temp_dir" do
+      it "stages uploads under /tmp on Linux" do
+        expect(transport[:temp_dir]).to eq "/tmp"
+      end
+
+      # Resolved inside the container rather than here, because the
+      # workstation's TEMP is unrelated to the container's.
+      it "stages uploads under the container's own TEMP on Windows" do
+        expect(transport({}, platform: "windows-2022")[:temp_dir]).to eq "$env:TEMP"
+      end
+    end
+
+    describe ":username" do
+      it "runs commands as the account the driver created" do
+        expect(transport[:username]).to eq "kitchen"
+      end
+
+      # There is no such account in a Windows image, and `-u` with a name that
+      # does not exist there fails every exec.
+      it "is unset on Windows" do
+        expect(transport({}, platform: "windows-2022")[:username]).to be_nil
+      end
+    end
+
+    describe ":socket" do
+      around do |example|
+        saved = ENV["DOCKER_HOST"]
+        example.run
+        saved.nil? ? ENV.delete("DOCKER_HOST") : ENV["DOCKER_HOST"] = saved
+      end
+
+      it "defaults to the Unix socket" do
+        ENV.delete("DOCKER_HOST")
+        allow(Gem).to receive(:win_platform?).and_return(false)
+        expect(transport[:socket]).to eq "unix:///var/run/docker.sock"
+      end
+
+      it "prefers DOCKER_HOST" do
+        ENV["DOCKER_HOST"] = "tcp://192.168.1.1:2375"
+        expect(transport[:socket]).to eq "tcp://192.168.1.1:2375"
+      end
+    end
+  end
+
+  describe "#connection" do
+    around do |example|
+      saved = ENV["DOCKER_HOST"]
+      example.run
+      saved.nil? ? ENV.delete("DOCKER_HOST") : ENV["DOCKER_HOST"] = saved
+    end
+
+    it "hands the connection the state as well as the configuration" do
+      ENV.delete("DOCKER_HOST")
+      conn = transport({ binary: "docker" }).connection(container_id: "abc123")
+      expect(conn.send(:options)).to include(binary: "docker", container_id: "abc123")
+    end
+
+    # The container classes decide between the Windows and Linux
+    # implementations from this, and it is not in the transport's own config.
+    it "records the platform under test" do
+      ENV.delete("DOCKER_HOST")
+      expect(transport({}, platform: "windows-2022").connection({}).send(:options)[:platform])
+        .to eq "windows-2022"
+    end
+
+    # The docker-api gem, which the InSpec verifier uses, reads the daemon
+    # address from the environment rather than from Test Kitchen's config.
+    it "exports the configured socket for the InSpec verifier" do
+      ENV.delete("DOCKER_HOST")
+      transport({ socket: "tcp://docker.example.com:2376" }).connection({})
+      expect(ENV["DOCKER_HOST"]).to eq "tcp://docker.example.com:2376"
+    end
+
+    it "leaves a DOCKER_HOST the user already exported alone" do
+      ENV["DOCKER_HOST"] = "tcp://mine.example.com:2375"
+      transport({ socket: "tcp://docker.example.com:2376" }).connection({})
+      expect(ENV["DOCKER_HOST"]).to eq "tcp://mine.example.com:2375"
+    end
+  end
 end
 
 describe Kitchen::Transport::Docker::Connection do
@@ -53,6 +143,54 @@ describe Kitchen::Transport::Docker::Connection do
   # than being spelled out. Pin it, so the inheritance cannot drift.
   it "inherits from the Test Kitchen base connection" do
     expect(described_class.superclass).to be Kitchen::Transport::Base::Connection
+  end
+
+  describe "#execute" do
+    it "runs the command inside the container" do
+      expect(connection.container).to receive(:execute).with("echo hi")
+      connection.execute("echo hi")
+    end
+
+    # Kitchen calls execute with nil for a provisioner that has nothing to run,
+    # such as a suite with an empty run_list.
+    it "does nothing when there is no command" do
+      expect(connection.container).not_to receive(:execute)
+      connection.execute(nil)
+    end
+
+    # A bare RuntimeError from the container layer is not something Kitchen
+    # recognises, so it surfaces as a stack trace rather than as a failed
+    # action naming the instance.
+    it "reports a failure as a transport failure" do
+      allow(connection.container).to receive(:execute).and_raise("boom")
+      expect { connection.execute("echo hi") }
+        .to raise_error(Kitchen::Transport::Docker::DockerFailed, /Docker failed to execute command/)
+    end
+  end
+
+  describe "#upload" do
+    it "hands the files to the container" do
+      expect(connection.container).to receive(:upload).with(["/local/f.rb"], "/tmp")
+      connection.upload(["/local/f.rb"], "/tmp")
+    end
+  end
+
+  describe "#container" do
+    it "builds a Linux container for a Linux platform" do
+      expect(connection.container).to be_a Kitchen::Docker::Container::Linux
+    end
+
+    it "reuses the same container across calls" do
+      expect(connection.container).to be connection.container
+    end
+
+    context "on a Windows container" do
+      let(:options) { { binary: "docker", container_id: "abc123", platform: "windows-2022" } }
+
+      it "builds a Windows container" do
+        expect(connection.container).to be_a Kitchen::Docker::Container::Windows
+      end
+    end
   end
 
   describe "#login_command" do


### PR DESCRIPTION
Line coverage of `lib/` was 85.3%, and the gaps were not obscure corners.

## What was untested

| Area | Why it matters |
| --- | --- |
| `Driver#default_image`, `#default_platform` | This is what makes "a platform name and nothing else" work, which is the first thing the README promises. Nothing asserted that `ubuntu-24.04` becomes `ubuntu:24.04`, or that `centos-7` becomes `centos:centos7`. |
| The driver's lazy `default_config` blocks | `image`, `platform`, `username`, `run_command`, `build_context`, `instance_name`, `package_name`, `socket`. |
| `Container#hostname` | Three branches — local, remote socket, internal network — all of which produce something that looks like a host, so getting it wrong fails later as a connection timeout rather than here. |
| `Container#upload`, `Container::Linux#create` | `create` populates the state the transport and verifier read; a key missing from it surfaces as a nil far from the cause. |
| Every public method on the transport | `#connection`, `Connection#execute`, `#upload`, `#container`, and the `temp_dir` / `username` / `socket` defaults. |
| `Driver#create`, `#destroy`, `#container`, `#wait_for_transport`, `#verify_dependencies` | |

## A spec that was testing itself

`describe "socket default config logic"` re-implemented the driver's `default_config :socket` block inside the spec file and asserted on its own copy:

```ruby
def resolve_socket
  socket = "unix:///var/run/docker.sock"
  socket = "npipe:////./pipe/docker_engine" if Gem.win_platform?
  ENV["DOCKER_HOST"] || socket
end
```

That passes with the driver's block deleted. It now reads the value back off a driver, which is what Test Kitchen does.

## Result

```
lib/kitchen/docker/container.rb              71.8% -> 100.0%
lib/kitchen/docker/container/linux.rb        88.8% -> 100.0%
lib/kitchen/driver/docker.rb                 78.8% -> 100.0%
lib/kitchen/transport/docker.rb              72.0% -> 100.0%
TOTAL                                        85.3% ->  94.5%
```

(measured with SimpleCov, which is not added to the Gemfile — it was only used to find the gaps)

The remaining gaps are `Container::Windows#execute` and three `ContainerHelper` methods, which #496 covers, and the InSpec verifier patches, which only run when kitchen-inspec is in the bundle — CI unit tests run with `BUNDLE_WITHOUT=development`, so they are not loaded there.

No production code is changed.

## Verification

```
$ bundle exec rake test
416 examples, 0 failures

$ cookstyle --chefstyle          # Cookstyle 9.0.0 / RuboCop 1.90.0
44 files inspected, no offenses detected
```